### PR TITLE
[WIP] 타이머 로직 구현 + 테스트를 위한 더미뷰

### DIFF
--- a/LullabyRecipe.xcodeproj/project.pbxproj
+++ b/LullabyRecipe.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		58DE61C22841C20A00F25769 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 58DE61C12841C20A00F25769 /* Launch Screen.storyboard */; };
 		58DE61C52841C54700F25769 /* OnBoarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DE61C42841C54700F25769 /* OnBoarding.swift */; };
 		58DE61C72843100100F25769 /* VolumeControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DE61C62843100100F25769 /* VolumeControl.swift */; };
+		E28DCEA0287A95D200AEA4D5 /* MusicTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28DCE9F287A95D200AEA4D5 /* MusicTimer.swift */; };
+		E28DCEA2287A98C600AEA4D5 /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28DCEA1287A98C600AEA4D5 /* TimerManager.swift */; };
+		E28DCEA4287AFC0D00AEA4D5 /* DummyTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28DCEA3287AFC0D00AEA4D5 /* DummyTimerView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,6 +116,9 @@
 		58DE61C12841C20A00F25769 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		58DE61C42841C54700F25769 /* OnBoarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OnBoarding.swift; path = LullabyRecipe/Views/Onboarding/OnBoarding.swift; sourceTree = SOURCE_ROOT; };
 		58DE61C62843100100F25769 /* VolumeControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeControl.swift; sourceTree = "<group>"; };
+		E28DCE9F287A95D200AEA4D5 /* MusicTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicTimer.swift; sourceTree = "<group>"; };
+		E28DCEA1287A98C600AEA4D5 /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
+		E28DCEA3287AFC0D00AEA4D5 /* DummyTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyTimerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -154,6 +160,7 @@
 				58DE61B6283A932E00F25769 /* Music.swift */,
 				58DE1020283DD9DD002CDB9F /* MusicViewModel.swift */,
 				58DE61C62843100100F25769 /* VolumeControl.swift */,
+				E28DCEA3287AFC0D00AEA4D5 /* DummyTimerView.swift */,
 			);
 			path = Music;
 			sourceTree = "<group>";
@@ -217,6 +224,7 @@
 			children = (
 				58DE101D283DC913002CDB9F /* AudioManager.swift */,
 				4A5769AF2866F6B5007CCAE9 /* UserDefaultsManager.swift */,
+				E28DCEA1287A98C600AEA4D5 /* TimerManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -311,6 +319,7 @@
 				58DE61B3283A8E4500F25769 /* Recipe.swift */,
 				4A5769AB2866F20A007CCAE9 /* MixedSound.swift */,
 				4A5769AD2866F44E007CCAE9 /* DummyData.swift */,
+				E28DCE9F287A95D200AEA4D5 /* MusicTimer.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -482,9 +491,12 @@
 				4A5769B02866F6B5007CCAE9 /* UserDefaultsManager.swift in Sources */,
 				58DE61B2283A8E1700F25769 /* Sound.swift in Sources */,
 				58DE61BD283E542400F25769 /* MixedSoundCard.swift in Sources */,
+				E28DCEA0287A95D200AEA4D5 /* MusicTimer.swift in Sources */,
 				58DE61C72843100100F25769 /* VolumeControl.swift in Sources */,
 				58DE61832839C13900F25769 /* LullabyRecipeApp.swift in Sources */,
 				4A5769AC2866F20A007CCAE9 /* MixedSound.swift in Sources */,
+				E28DCEA4287AFC0D00AEA4D5 /* DummyTimerView.swift in Sources */,
+				E28DCEA2287A98C600AEA4D5 /* TimerManager.swift in Sources */,
 				58DE61B4283A8E4500F25769 /* Recipe.swift in Sources */,
 				58DE101C283CA87F002CDB9F /* SoundCard.swift in Sources */,
 				4A5769AE2866F44E007CCAE9 /* DummyData.swift in Sources */,

--- a/LullabyRecipe/ContentView.swift
+++ b/LullabyRecipe/ContentView.swift
@@ -44,10 +44,12 @@ struct ContentView: View {
             .edgesIgnoringSafeArea(.bottom)
         }
         .onReceive(timer.musicTimer.timer) { _ in
-            if timer.isShutDown() && timer.timerOn {
+            if timer.isShutDown() && timer.isTimerOn {
                 timer.endMusicAndTimer()
             }
-            timer.countDown()
+            if timer.isTimerOn && !timer.isTimerStop {
+                timer.countDown()
+            }
         }
         .onAppear() {
             let notFirstVisit = UserDefaultsManager.shared.standard.bool(forKey: UserDefaultsManager.shared.notFirstVisit)

--- a/LullabyRecipe/ContentView.swift
+++ b/LullabyRecipe/ContentView.swift
@@ -19,6 +19,8 @@ struct ContentView: View {
     @State var showOnboarding: Bool = false
     @State var userName: String?
     
+    @ObservedObject var timer = TimerManager.shared
+    
     var body: some View {
         NavigationView {
             VStack {
@@ -40,6 +42,12 @@ struct ContentView: View {
             .background(ColorPalette.background.color,
                         ignoresSafeAreaEdges: .all)
             .edgesIgnoringSafeArea(.bottom)
+        }
+        .onReceive(timer.musicTimer.timer) { _ in
+            if timer.isShutDown() && timer.timerOn {
+                timer.endMusicAndTimer()
+            }
+            timer.countDown()
         }
         .onAppear() {
             let notFirstVisit = UserDefaultsManager.shared.standard.bool(forKey: UserDefaultsManager.shared.notFirstVisit)

--- a/LullabyRecipe/Manager/TimerManager.swift
+++ b/LullabyRecipe/Manager/TimerManager.swift
@@ -14,7 +14,9 @@ class TimerManager: ObservableObject {
     @Published var musicTimer = MusicTimer()
     var musicViewModel = MusicViewModel.shared
 
-    var timerOn: Bool {musicTimer.timerOn}
+    var isTimerOn: Bool {musicTimer.isTimerOn}
+    var isTimerStop: Bool {musicTimer.isTimerStop}
+
     
     /// 남은 시간 0이 될 경우
     func isShutDown() -> Bool {
@@ -38,16 +40,16 @@ class TimerManager: ObservableObject {
     
     func start(time: Int) {
         musicTimer.setTime(second: time)
-        musicTimer.timerOn = true
+        musicTimer.isTimerOn = true
     }
     
     func endMusicAndTimer() {
-        musicTimer.timerOn = false
+        musicTimer.isTimerOn = false
         musicViewModel.stop()
         musicViewModel.isPlaying = false
     }
     
     func toggleTimerStop() {
-        musicTimer.timerStop.toggle()
+        musicTimer.isTimerStop.toggle()
     }
 }

--- a/LullabyRecipe/Manager/TimerManager.swift
+++ b/LullabyRecipe/Manager/TimerManager.swift
@@ -1,0 +1,46 @@
+//
+//  TimerManager.swift
+//  LullabyRecipe
+//
+//  Created by hyo on 2022/07/10.
+//
+
+import Foundation
+
+
+class TimerManager: ObservableObject {
+    static let shared = TimerManager()
+    
+    @Published var musicTimer = MusicTimer()
+    var timerOn: Bool {musicTimer.timerOn}
+    
+    /// 남은 시간 0이 될 경우
+    func isShutDown() -> Bool {
+        if getRemainedSecond() == 0 {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    /// 1초씩 감소
+    func countDown() {
+        if musicTimer.remainedSecond > 0 {
+            musicTimer.remainedSecond -= 1
+        }
+    }
+
+    func getRemainedSecond() -> Int {
+        return musicTimer.remainedSecond
+    }
+    
+    func start(time: Int) {
+        musicTimer.setTime(second: time)
+        musicTimer.timerOn = true
+    }
+    
+    
+    func toggleTimerStop() {
+        musicTimer.timerStop.toggle()
+    }
+}

--- a/LullabyRecipe/Manager/TimerManager.swift
+++ b/LullabyRecipe/Manager/TimerManager.swift
@@ -12,6 +12,8 @@ class TimerManager: ObservableObject {
     static let shared = TimerManager()
     
     @Published var musicTimer = MusicTimer()
+    var musicViewModel = MusicViewModel.shared
+
     var timerOn: Bool {musicTimer.timerOn}
     
     /// 남은 시간 0이 될 경우
@@ -39,6 +41,11 @@ class TimerManager: ObservableObject {
         musicTimer.timerOn = true
     }
     
+    func endMusicAndTimer() {
+        musicTimer.timerOn = false
+        musicViewModel.stop()
+        musicViewModel.isPlaying = false
+    }
     
     func toggleTimerStop() {
         musicTimer.timerStop.toggle()

--- a/LullabyRecipe/Model/MusicTimer.swift
+++ b/LullabyRecipe/Model/MusicTimer.swift
@@ -1,0 +1,21 @@
+//
+//  Timer.swift
+//  LullabyRecipe
+//
+//  Created by hyo on 2022/07/10.
+//
+
+import SwiftUI
+
+struct MusicTimer {
+    let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    
+    var timerOn: Bool = false
+    var timerStop: Bool = false
+
+    var remainedSecond: Int = 0
+    
+    mutating func setTime(second: Int) {
+        remainedSecond = second
+    }
+}

--- a/LullabyRecipe/Model/MusicTimer.swift
+++ b/LullabyRecipe/Model/MusicTimer.swift
@@ -10,12 +10,13 @@ import SwiftUI
 struct MusicTimer {
     let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     
-    var timerOn: Bool = false
-    var timerStop: Bool = false
+    var isTimerOn: Bool = false
+    var isTimerStop: Bool = false
 
     var remainedSecond: Int = 0
     
     mutating func setTime(second: Int) {
         remainedSecond = second
     }
+
 }

--- a/LullabyRecipe/Model/Sound.swift
+++ b/LullabyRecipe/Model/Sound.swift
@@ -15,19 +15,6 @@ struct Sound: Identifiable, Codable {
     let imageName: String
 }
 
-struct MixedSound: Identifiable, Codable, Equatable {
-    static func == (lhs: MixedSound, rhs: MixedSound) -> Bool {
-        return true
-    }
-    
-    let id: Int
-    let name: String
-    var baseSound: Sound?
-    var melodySound: Sound?
-    var naturalSound: Sound?
-    let imageName: String
-}
-
 var baseSounds = [
     Sound(id: 0,
           name: "Empty",

--- a/LullabyRecipe/Views/Home/Home.swift
+++ b/LullabyRecipe/Views/Home/Home.swift
@@ -167,6 +167,7 @@ struct Home: View {
         }
     }
 }
+
 struct RoundedEdge: ViewModifier {
     let width: CGFloat
     let color: Color
@@ -182,6 +183,8 @@ struct RoundedEdge: ViewModifier {
 
 struct Home_Previews: PreviewProvider {
     static var previews: some View {
-        Home(userName: .constant("guest"), selected: .constant(.home))
+        NavigationView {
+            Home(userName: .constant("guest"), selected: .constant(.home))
+        }
     }
 }

--- a/LullabyRecipe/Views/Home/MixedSoundCard.swift
+++ b/LullabyRecipe/Views/Home/MixedSoundCard.swift
@@ -86,8 +86,8 @@ struct MixedSoundCard : View {
 struct MixedSoundCard_Previews: PreviewProvider {
     static var previews: some View {
         let dummyMixedSound = dummyMixedSound
-//        MixedSoundCard(data: dummyMixedSound,
-//                       selectedID: "", hasEdited: .constant(false))
-//        .background(ColorPalette.background.color)
+        MixedSoundCard(data: dummyMixedSound,
+                       selectedID: "", hasEdited: .constant(false), audioVolumes: (baseVolume: Float(1.0), melodyVolume: Float(1.0), naturalVolume: Float(1.0)))
+        .background(ColorPalette.background.color)
     }
 }

--- a/LullabyRecipe/Views/Home/Music/DummyTimerView.swift
+++ b/LullabyRecipe/Views/Home/Music/DummyTimerView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct DummyTimerView: View {
-//    @ObservedObject var musicViewModel: MusicViewModel
     @ObservedObject var timer = TimerManager.shared
     @State var second: Double = 0
 
@@ -34,8 +33,12 @@ struct DummyTimerView: View {
     
     var editTimerView: some View {
         VStack {
-//            Text("\(musicViewModel.isPlaying ? "true":"false")")
             Text("\(timer.getRemainedSecond())")
+            Button {
+                timer.musicTimer.isTimerOn = false
+            } label : {
+                Text("cancel")
+            }
         }
     }
 }
@@ -43,6 +46,5 @@ struct DummyTimerView: View {
 struct DummyTimerView_Previews: PreviewProvider {
     static var previews: some View {
         DummyTimerView()
-//            .onReceive(Publisher, perform: <#T##(Publisher.Output) -> Void#>)
     }
 }

--- a/LullabyRecipe/Views/Home/Music/DummyTimerView.swift
+++ b/LullabyRecipe/Views/Home/Music/DummyTimerView.swift
@@ -13,7 +13,7 @@ struct DummyTimerView: View {
     @State var second: Double = 0
 
     var body: some View {
-        if timer.timerOn {
+        if timer.isTimerOn {
             editTimerView
         } else {
             setTimerView

--- a/LullabyRecipe/Views/Home/Music/DummyTimerView.swift
+++ b/LullabyRecipe/Views/Home/Music/DummyTimerView.swift
@@ -1,0 +1,48 @@
+//
+//  DummyTimerView.swift
+//  LullabyRecipe
+//
+//  Created by hyo on 2022/07/10.
+//
+
+import SwiftUI
+
+struct DummyTimerView: View {
+//    @ObservedObject var musicViewModel: MusicViewModel
+    @ObservedObject var timer = TimerManager.shared
+    @State var second: Double = 0
+
+    var body: some View {
+        if timer.timerOn {
+            editTimerView
+        } else {
+            setTimerView
+        }
+    }
+    
+    var setTimerView: some View {
+        VStack {
+            Text("\(second)")
+            Slider(value: $second, in: 1...60, step: 1)
+            Button {
+                timer.start(time: Int(second))
+            } label: {
+                Text("start")
+            }
+        }
+    }
+    
+    var editTimerView: some View {
+        VStack {
+//            Text("\(musicViewModel.isPlaying ? "true":"false")")
+            Text("\(timer.getRemainedSecond())")
+        }
+    }
+}
+
+struct DummyTimerView_Previews: PreviewProvider {
+    static var previews: some View {
+        DummyTimerView()
+//            .onReceive(Publisher, perform: <#T##(Publisher.Output) -> Void#>)
+    }
+}

--- a/LullabyRecipe/Views/Home/Music/Music.swift
+++ b/LullabyRecipe/Views/Home/Music/Music.swift
@@ -120,7 +120,6 @@ struct MusicView: View {
             viewModel.play()
             viewModel.isPlaying.toggle()
         }, label: {
-            
             HStack {
                 (Text("\(viewModel.isPlaying ? "Pause " : "Play ")").bold() + Text(Image(systemName: viewModel.isPlaying ? "pause.fill" : "play.fill")))
                     .frame(minWidth: 0,
@@ -130,13 +129,18 @@ struct MusicView: View {
                     .foregroundColor(.white)
                     .cornerRadius(17)
                     .font(.system(size: 16))
+                dummyTimerButton
             }
         })
-        
-        //        }
-        //        .frame(width: maxWidth,
-        //               height: maxWidth)
-        //        .padding(.top,30)
+    }
+    
+    var dummyTimerButton: some View {
+        HStack {
+            NavigationLink(destination: DummyTimerView()) {
+                Image(systemName: "timer")
+            }
+            Text("\(timer.getRemainedSecond())")
+        }
     }
     
     @ViewBuilder

--- a/LullabyRecipe/Views/Home/Music/Music.swift
+++ b/LullabyRecipe/Views/Home/Music/Music.swift
@@ -180,16 +180,25 @@ struct MusicView: View {
     }
 }
 
+struct MusicViewForBinding: View {
+    @State var audioVolumes = (baseVolume: Float(1.0), melodyVolume: Float(1.0), naturalVolume: Float(1.0))
+
+    let dummyMixedSound = MixedSound(id: 3,
+                                     name: "test4",
+                                     baseSound: dummyBaseSound,
+                                     melodySound: dummyMelodySound,
+                                     naturalSound: dummyNaturalSound,
+                                     imageName: "r1")
+    var body: some View {
+        MusicView(data: dummyMixedSound, audioVolumes: $audioVolumes)
+    }
+}
+
 struct Music_Previews: PreviewProvider {
     static var previews: some View {
-        let dummyMixedSound = MixedSound(id: 3,
-                                         name: "test4",
-                                         baseSound: dummyBaseSound,
-                                         melodySound: dummyMelodySound,
-                                         naturalSound: dummyNaturalSound,
-                                         imageName: "r1")
-    
-//        MusicView(data: dummyMixedSound)
+        NavigationView {
+            MusicViewForBinding()
+        }
     }
 }
 

--- a/LullabyRecipe/Views/Home/Music/Music.swift
+++ b/LullabyRecipe/Views/Home/Music/Music.swift
@@ -9,18 +9,19 @@ import SwiftUI
 import AVKit
 
 struct MusicView: View {
+    @StateObject var viewModel = MusicViewModel.shared
     
-    @StateObject var viewModel = MusicViewModel()
     @State var animatedValue : CGFloat = 55
     @State var maxWidth = UIScreen.main.bounds.width / 2.2
     @State var showVolumeControl: Bool = false
     
+    @ObservedObject var timer = TimerManager.shared
+
     var data: MixedSound
     
     @Binding var audioVolumes: (baseVolume: Float, melodyVolume: Float, naturalVolume: Float)
     
     var body: some View {
-        
         ZStack(alignment: .top) {
             
             ColorPalette.background.color.ignoresSafeArea()
@@ -55,9 +56,9 @@ struct MusicView: View {
             .onAppear {
                 viewModel.fetchData(data: data)
             }
-            .onDisappear {
-                viewModel.stop()
-            }
+//            .onDisappear {
+//                viewModel.stop()
+//            }
         }
         .sheet(isPresented: $showVolumeControl,
                content: {
@@ -205,5 +206,3 @@ struct Music_Previews: PreviewProvider {
         }
     }
 }
-
-

--- a/LullabyRecipe/Views/Home/Music/MusicViewModel.swift
+++ b/LullabyRecipe/Views/Home/Music/MusicViewModel.swift
@@ -9,6 +9,9 @@ import SwiftUI
 import AVFoundation
 
 final class MusicViewModel: NSObject, ObservableObject {
+    
+    static let shared = MusicViewModel()
+    
     @Published var baseAudioManager = AudioManager()
     @Published var melodyAudioManager = AudioManager()
     @Published var naturalAudioManager = AudioManager()


### PR DESCRIPTION
---
name: Pull Request Tamplate
about: PR 템플릿
title: "[Label] PR Title"
labels: ['feature']

---
## Close Issues
Close #40 

## Pull Request 내용
- 타이머 동작하도록 구현
  - 타이머 값 설정
  - 타이머 종료시 음악 종료
  - 타이머 취소

## 관련 사진(Optional)
<img width="808" alt="image" src="https://user-images.githubusercontent.com/59302419/178208011-4a6270d8-6323-445f-a9bf-46e615870805.png">

## problem
- **타이머를 어디서 설정할지 논의 필요**
  - 음악 듣는 곳에서(현재 구현 방식) or 별도의 설정 탭에서
- **타이머 적용 범위 논의 필요**
  - 특정 음악에만 적용할지 or 하나의 global 타이머를 설정하면 모든 음악에 대해 적용할지

- NavigationView와 onReceive를 같이 사용할 경우 onReceive가 동작하지 않는 문제 발생 ->  onReceive를 NavigationView 밖에에 두는 것으로 임시해결 -> **타이머를 사용하지 않아도 onReceive가 계속 돌아가는 문제 발생**
  - <img width="797" alt="image" src="https://user-images.githubusercontent.com/59302419/178209539-3a056ef4-5f52-4a26-9834-8f0a84e5bf90.png">

- 타이머 종료시 음악 종료를 위해서 MusicViewModel을 가져올 필요가 있다. ->  음악마다 MusicViewModel을 각각 가지고 있는데 해당 MusicViewModel을 onReceive로 가져오기가 애매함(NavigationView 밖에 있기 때문에) -> 일단은 MusicViewModel을 싱글톤으로 변경하는 것으로 임시해결 -> **다른 음악으로 들어가면 play 버튼이 꼬이는 버그 존재**
  - <img width="634" alt="image" src="https://user-images.githubusercontent.com/59302419/178209872-6eeb8733-e405-4ebf-8970-00e4fbd6c0f5.png">



