### PR TITLE
[Fix]: #77 color name 변경

### DIFF
--- a/LullabyRecipe/Views/CustomTabView.swift
+++ b/LullabyRecipe/Views/CustomTabView.swift
@@ -21,7 +21,7 @@ struct CustomTabView : View {
                         .frame(height: 5)
                         .overlay(
                             Capsule()
-                                .fill(self.selected == selectedTab ? Color("Forground") : Color.clear)
+                                .fill(self.selected == selectedTab ? ColorPalette.forground.color : Color.clear)
                                 .frame(width: 55, height: 5)
                         )
                     Button(action: {


### PR DESCRIPTION
## 작업 내용 (Content)
- 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 간략하게 작성합니다.
리팩토링하다가 발견한 오류로, "Color("Forground")"라고 하드 코딩이 되어있었습니다. 
Static에서 정의했던 enum을 이용한 ColorPalette.forground.color 로 변경했습니다.

## 기타 사항 (Etc)
- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #77

## 관련 사진(Optional)
