### PR TITLE
[Feat] forced unwrapped 삭제

### DIFF
--- a/LullabyRecipe.xcodeproj/project.pbxproj
+++ b/LullabyRecipe.xcodeproj/project.pbxproj
@@ -110,7 +110,6 @@
 		58DE619F2839C13B00F25769 /* LullabyRecipeUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LullabyRecipeUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		58DE61AE283A8C8B00F25769 /* KitchenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KitchenView.swift; sourceTree = "<group>"; };
 		58DE61B1283A8E1700F25769 /* Sound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sound.swift; sourceTree = "<group>"; };
-		58DE61B3283A8E4500F25769 /* Recipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Recipe.swift; sourceTree = "<group>"; };
 		58DE61B6283A932E00F25769 /* MusicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicView.swift; sourceTree = "<group>"; };
 		58DE61B8283A937000F25769 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		58DE61BC283E542400F25769 /* MixedSoundCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedSoundCardView.swift; sourceTree = "<group>"; };
@@ -235,9 +234,9 @@
 		58DE103828405C6C002CDB9F /* Kitchen */ = {
 			isa = PBXGroup;
 			children = (
-                10D26713288EF4D20056339A /* RectPreference.swift */,
-                10D26711288EF4C80056339A /* CustomSegmentControlView.swift */,
-                58DE1033283F1A0A002CDB9F /* CustomAlertView.swift */,
+				10D26713288EF4D20056339A /* RectPreference.swift */,
+				10D26711288EF4C80056339A /* CustomSegmentControlView.swift */,
+				58DE1033283F1A0A002CDB9F /* CustomAlertView.swift */,
 				58DE61AE283A8C8B00F25769 /* KitchenView.swift */,
 				58DE101B283CA87F002CDB9F /* SoundCardView.swift */,
 				10D26715288EF4DB0056339A /* StudioView.swift */,
@@ -510,12 +509,11 @@
 				58DE61832839C13900F25769 /* LullabyRecipeApp.swift in Sources */,
 				10D26716288EF4DB0056339A /* StudioView.swift in Sources */,
 				4A5769AC2866F20A007CCAE9 /* MixedSound.swift in Sources */,
-				58DE61B4283A8E4500F25769 /* Recipe.swift in Sources */,
 				58DE101C283CA87F002CDB9F /* SoundCardView.swift in Sources */,
 				4A5769AE2866F44E007CCAE9 /* DummyData.swift in Sources */,
 				CC2820482880102400587334 /* ViewModifiers.swift in Sources */,
 				58DE101E283DC913002CDB9F /* AudioManager.swift in Sources */,
-                10D26714288EF4D20056339A /* RectPreference.swift in Sources */,
+				10D26714288EF4D20056339A /* RectPreference.swift in Sources */,
 				58DE1034283F1A0A002CDB9F /* CustomAlertView.swift in Sources */,
 				58DE61B7283A932E00F25769 /* MusicView.swift in Sources */,
 				58DE61B9283A937000F25769 /* HomeView.swift in Sources */,
@@ -691,7 +689,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LullabyRecipe/Preview Content\"";
-				DEVELOPMENT_TEAM = QGAQ3AY3R3;
+				DEVELOPMENT_TEAM = JP5BCXZWJP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LullabyRecipe/Info.plist;
@@ -721,7 +719,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LullabyRecipe/Preview Content\"";
-				DEVELOPMENT_TEAM = QGAQ3AY3R3;
+				DEVELOPMENT_TEAM = JP5BCXZWJP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LullabyRecipe/Info.plist;

--- a/LullabyRecipe/Manager/AudioManager.swift
+++ b/LullabyRecipe/Manager/AudioManager.swift
@@ -20,14 +20,15 @@ final class AudioManager {
     }
     
     func startPlayer(track: String, volume: Float? = 1.0) {
-        guard let url = getPathUrl(forResource: track, musicExtension: .mp3) else {
+        guard let url = getPathUrl(forResource: track, musicExtension: .mp3),
+              let volume = volume else {
             print("resource not found \(track)")
             return
         }
         
         do {
             player = try AVAudioPlayer(contentsOf: url)
-            player?.volume = volume!
+            player?.volume = volume
             player?.numberOfLoops = -1
             player?.play()
         } catch {
@@ -57,7 +58,7 @@ final class AudioManager {
         }
     }
     
-    func chanegeVolume(track: String, volume: Float) {
+    func changeVolume(track: String, volume: Float) {
         
         guard let url = getPathUrl(forResource: track, musicExtension: .mp3) else {
             print("resource not found \(track)")

--- a/LullabyRecipe/Model/Sound.swift
+++ b/LullabyRecipe/Model/Sound.swift
@@ -114,6 +114,12 @@ var naturalSounds = [
           imageName: NaturalAudioName.wave.fileName)
 ]
 
+let emptySound: Sound  = Sound(id: 0,
+                               name: "Empty",
+                               soundType: .base,
+                               audioVolume: 0.0,
+                               imageName: "music")
+
 var baseSound: Sound = Sound(id: 0,
                              name: "Empty",
                              soundType: .base,

--- a/LullabyRecipe/Model/Sound.swift
+++ b/LullabyRecipe/Model/Sound.swift
@@ -114,7 +114,7 @@ var naturalSounds = [
           imageName: NaturalAudioName.wave.fileName)
 ]
 
-let emptySound: Sound  = Sound(id: 0,
+let emptySound: Sound = Sound(id: 0,
                                name: "Empty",
                                soundType: .base,
                                audioVolume: 0.0,

--- a/LullabyRecipe/Views/Home/MixedSoundCardView.swift
+++ b/LullabyRecipe/Views/Home/MixedSoundCardView.swift
@@ -16,20 +16,20 @@ struct MixedSoundCardView: View {
     @State var showingActionSheet: Bool = false
     
     @State var audioVolumes: (baseVolume: Float, melodyVolume: Float, naturalVolume: Float)
-
+    
     var body : some View {
         ZStack {
             NavigationLink(destination: MusicView(data: data, audioVolumes: $audioVolumes),
                            isActive: $show) {
                 Text("")
             }
-
+            
             VStack(alignment: .leading, spacing: 10) {
                 Image(data.imageName)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .cornerRadius(10)
-
+                
                 Text(data.name)
                     .fontWeight(.semibold)
                     .font(Font.system(size: 17))
@@ -55,8 +55,9 @@ struct MixedSoundCardView: View {
                 .offset(y: -14)
             }
         }
-        .confirmationDialog("Are you sure?",
-          isPresented: $showingActionSheet) {
+        .confirmationDialog(Text("Are you sure?"),
+                            isPresented: $showingActionSheet,
+                            titleVisibility: .visible) {
             Button("Delete items", role: .destructive) {
                 hasEdited.toggle()
                 userRepositories.remove(at: data.id)
@@ -67,7 +68,7 @@ struct MixedSoundCardView: View {
                 hasEdited.toggle()
             }
         } message: {
-          Text("This item will be deleted. This action cannot be undone.")
+            Text("This item will be deleted. This action cannot be undone.")
         }
     }
     
@@ -86,8 +87,8 @@ struct MixedSoundCardView: View {
 struct MixedSoundCardView_Previews: PreviewProvider {
     static var previews: some View {
         let dummyMixedSound = dummyMixedSound
-//        MixedSoundCard(data: dummyMixedSound,
-//                       selectedID: "", hasEdited: .constant(false))
-//        .background(ColorPalette.background.color)
+        //        MixedSoundCard(data: dummyMixedSound,
+        //                       selectedID: "", hasEdited: .constant(false))
+        //        .background(ColorPalette.background.color)
     }
 }

--- a/LullabyRecipe/Views/Home/Music/MusicView.swift
+++ b/LullabyRecipe/Views/Home/Music/MusicView.swift
@@ -20,7 +20,6 @@ struct MusicView: View {
     @Binding var audioVolumes: (baseVolume: Float, melodyVolume: Float, naturalVolume: Float)
     
     var body: some View {
-        
         ZStack(alignment: .top) {
             
             ColorPalette.background.color.ignoresSafeArea()
@@ -34,17 +33,17 @@ struct MusicView: View {
                     Divider()
                         .background(.white)
                         .padding(.horizontal, 20)
-                    SingleSong(song: data.baseSound!)
+                    SingleSong(song: data.baseSound ?? emptySound)
                     
                     Divider()
                         .background(.white)
                         .padding(.horizontal, 20)
-                    SingleSong(song: data.melodySound!)
+                    SingleSong(song: data.melodySound ?? emptySound)
                     
                     Divider()
                         .background(.white)
                         .padding(.horizontal, 20)
-                    SingleSong(song: data.naturalSound!)
+                    SingleSong(song: data.naturalSound ?? emptySound)
                 }
                 
                 
@@ -62,8 +61,8 @@ struct MusicView: View {
         .sheet(isPresented: $showVolumeControl,
                content: {
             VolumeControlView(showVolumeControl: $showVolumeControl,
-                          audioVolumes: $audioVolumes,
-                          data: data)
+                              audioVolumes: $audioVolumes,
+                              data: data)
             .onDisappear {
                 viewModel.updateVolume(audioVolumes: audioVolumes)
             }
@@ -71,7 +70,6 @@ struct MusicView: View {
         .navigationBarTitle(Text(""),
                             // Todo :- edit 버튼 동작 .toolbar(content: { Button("Edit") { }}) }}
                             displayMode: .inline)
-        
     }
     
     @ViewBuilder
@@ -189,8 +187,8 @@ struct MusicView_Previews: PreviewProvider {
                                          melodySound: dummyMelodySound,
                                          naturalSound: dummyNaturalSound,
                                          imageName: "r1")
-    
-//        MusicView(data: dummyMixedSound)
+        
+        //        MusicView(data: dummyMixedSound)
     }
 }
 

--- a/LullabyRecipe/Views/Home/Music/VolumeControlView.swift
+++ b/LullabyRecipe/Views/Home/Music/VolumeControlView.swift
@@ -43,26 +43,26 @@ struct VolumeControlView: View {
                         melodyAudioManager.stop()
                         naturalAudioManager.stop()
                         // TODO: - 볼륨 저장
-                        let localBaseSound = data.baseSound
-                        let localMelodySound = data.melodySound
-                        let localNaturalSound = data.naturalSound
+                        guard let localBaseSound = data.baseSound,
+                              let localMelodySound = data.melodySound,
+                              let localNaturalSound = data.naturalSound else { return }
                         
-                        let newBaseSound = Sound(id: localBaseSound!.id,
-                                                 name: localBaseSound!.name,
-                                                 soundType: localBaseSound!.soundType,
+                        let newBaseSound = Sound(id: localBaseSound.id,
+                                                 name: localBaseSound.name,
+                                                 soundType: localBaseSound.soundType,
                                                  audioVolume: audioVolumes.baseVolume,
-                                                 imageName: localBaseSound!.imageName)
-                        let newMelodySound = Sound(id: localMelodySound!.id,
-                                                   name: localMelodySound!.name,
-                                                   soundType: localMelodySound!.soundType,
+                                                 imageName: localBaseSound.imageName)
+                        let newMelodySound = Sound(id: localMelodySound.id,
+                                                   name: localMelodySound.name,
+                                                   soundType: localMelodySound.soundType,
                                                    audioVolume: audioVolumes.melodyVolume,
-                                                   imageName: localMelodySound!.imageName)
+                                                   imageName: localMelodySound.imageName)
                         
-                        let newNaturalSound = Sound(id: localNaturalSound!.id,
-                                                    name: localNaturalSound!.name,
-                                                    soundType: localNaturalSound!.soundType,
+                        let newNaturalSound = Sound(id: localNaturalSound.id,
+                                                    name: localNaturalSound.name,
+                                                    soundType: localNaturalSound.soundType,
                                                     audioVolume: audioVolumes.naturalVolume,
-                                                    imageName: localNaturalSound!.imageName)
+                                                    imageName: localNaturalSound.imageName)
                         
                         let newMixedSound = MixedSound(id: data.id,
                                                        name: data.name,
@@ -146,7 +146,7 @@ struct VolumeControlView: View {
                         .padding(.horizontal, 20)
                         .onChange(of: audioVolumes.baseVolume) { newValue in
                             print(newValue)
-                            baseAudioManager.chanegeVolume(track: item.name,
+                            baseAudioManager.changeVolume(track: item.name,
                                                            volume: newValue)
                         }
                 case .melody:
@@ -157,7 +157,7 @@ struct VolumeControlView: View {
                         .padding(.horizontal, 20)
                         .onChange(of: audioVolumes.melodyVolume) { newValue in
                             print(newValue)
-                            melodyAudioManager.chanegeVolume(track: item.name,
+                            melodyAudioManager.changeVolume(track: item.name,
                                                              volume: newValue)
                         }
                 case .natural:
@@ -168,7 +168,7 @@ struct VolumeControlView: View {
                         .padding(.horizontal, 20)
                         .onChange(of: audioVolumes.naturalVolume) { newValue in
                             print(newValue)
-                            naturalAudioManager.chanegeVolume(track: item.name,
+                            naturalAudioManager.changeVolume(track: item.name,
                                                               volume: newValue)
                         }
                 }

--- a/LullabyRecipe/Views/Kitchen/CustomAlertView.swift
+++ b/LullabyRecipe/Views/Kitchen/CustomAlertView.swift
@@ -57,7 +57,7 @@ struct CustomAlertView: View {
                                               baseSound: baseSound,
                                               melodySound: melodySound,
                                               naturalSound: naturalSound,
-                                              imageName: recipeRandomName.randomElement()!)
+                                              imageName: recipeRandomName.randomElement() ?? "")
                     userRepositories.append(newSound)
                     
                     let data = getEncodedData(data: userRepositories)


### PR DESCRIPTION
## 작업 내용 (Content)
- forced unwrapping 제거했습니다.
- confirmationdialog에서 title이 뜨지 않는 현상 수정
- Audiomanager에 있던 오타 수정 (chanegeVolume() -> changeVolume())

## 기타 사항 (Etc)
- musicView의 forcedunwrapping을 해결하기 위해 두 가지 방법을 생각했었습니다.

1.
```
 if let baseSound = data.baseSound,
    let melodySound = data.melodySound,
    let naturalSound = data.naturalSound {
      ZStack(alignment: .top) {
            
            ColorPalette.background.color.ignoresSafeArea()
            
            VStack {
                MusicInfo()
                
                Divider()
                
                VStack(spacing: 20) {
                    Divider()
                        .background(.white)
                        .padding(.horizontal, 20)
                    SingleSong(song: baseSound)
   
      ...code...
  }
}
```
2.
```
SingleSong(song: data.baseSound ?? baseSounds[0])
```
위 두 가지 방법을 가지고 고민을 하고 있었는데 if let과 같은 unwrapping 요소가 view안에 들어가는 것은 저희가 지향하려 하는 MVVM 패턴에 맞지 않기 때문에 2번 방법을 택했습니다. 그런데 2번 방법에서도 baseSounds[0]을 봤을 때 
```
Sound(id: 0,
          name: "Empty",
          soundType: .base,
          audioVolume: 0.8,
          imageName: "music")
```
위와 같은 코드를 명확히 알기 어렵다고 생각하여 다음과 같은 emptySound를 `Sound.swift`에 만들어 모두에게 적용해줬습니다.
```
let emptySound: Sound  = Sound(id: 0,
                               name: "Empty",
                               soundType: .base,
                               audioVolume: 0.0,
                               imageName: "music")
```
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #이슈넘버
- close #97 
## 관련 사진(Optional)