### PR TITLE
[feat] #107 : Asset에 컬러 추가

### DIFF
--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		21D3ED952892774F006E871F /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5769AF2866F6B5007CCAE9 /* UserDefaultsManager.swift */; };
 		21D3ED972892781D006E871F /* CustomTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF0D9882887748500F61495 /* CustomTabView.swift */; };
 		21D897782892D48600A20FFE /* CDCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D897772892D48600A20FFE /* CDCardView.swift */; };
+		21FE2BB82899606A0024DA92 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FE2BB72899606A0024DA92 /* Extension.swift */; };
 		4A5769AC2866F20A007CCAE9 /* MixedSound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5769AB2866F20A007CCAE9 /* MixedSound.swift */; };
 		4A5769AE2866F44E007CCAE9 /* DummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5769AD2866F44E007CCAE9 /* DummyData.swift */; };
 		580CADAA28659BEF0091946C /* LongSun.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 580CADA928659BEF0091946C /* LongSun.mp3 */; };
@@ -65,6 +66,7 @@
 		2150BD0E2876CB89006C8312 /* CustomTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabView.swift; sourceTree = "<group>"; };
 		219BD67228900A28006FAF55 /* CDListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDListView.swift; sourceTree = "<group>"; };
 		21D897772892D48600A20FFE /* CDCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDCardView.swift; sourceTree = "<group>"; };
+		21FE2BB72899606A0024DA92 /* Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
 		4A5769AB2866F20A007CCAE9 /* MixedSound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedSound.swift; sourceTree = "<group>"; };
 		4A5769AD2866F44E007CCAE9 /* DummyData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyData.swift; sourceTree = "<group>"; };
 		4A5769AF2866F6B5007CCAE9 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 				58DE1031283DF6E7002CDB9F /* Static.swift */,
 				CCA7F5202877501E00D6A239 /* Localizable.strings */,
 				CC2820472880102400587334 /* ViewModifiers.swift */,
+				21FE2BB72899606A0024DA92 /* Extension.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -419,6 +422,7 @@
 				102CCFFA289101AD00B97F8F /* TestNavigateView.swift in Sources */,
 				58DE61832839C13900F25769 /* RelaxOnApp.swift in Sources */,
 				21D3ED972892781D006E871F /* CustomTabView.swift in Sources */,
+				21FE2BB82899606A0024DA92 /* Extension.swift in Sources */,
 				10D26716288EF4DB0056339A /* StudioView.swift in Sources */,
 				4A5769AC2866F20A007CCAE9 /* MixedSound.swift in Sources */,
 				58DE101C283CA87F002CDB9F /* SoundCardView.swift in Sources */,

--- a/RelaxOn/Assets.xcassets/Color.colorset/Contents.json
+++ b/RelaxOn/Assets.xcassets/Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RelaxOn/Assets.xcassets/Colors/Main Colors/Contents.json
+++ b/RelaxOn/Assets.xcassets/Colors/Main Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RelaxOn/Assets.xcassets/Colors/Main Colors/RelaxBlack.colorset/Contents.json
+++ b/RelaxOn/Assets.xcassets/Colors/Main Colors/RelaxBlack.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1B",
+          "green" : "0x1B",
+          "red" : "0x1B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1B",
+          "green" : "0x1B",
+          "red" : "0x1B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RelaxOn/Assets.xcassets/Colors/Main Colors/RelaxDimPurple.colorset/Contents.json
+++ b/RelaxOn/Assets.xcassets/Colors/Main Colors/RelaxDimPurple.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFC",
+          "green" : "0x84",
+          "red" : "0x98"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFC",
+          "green" : "0x84",
+          "red" : "0x98"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RelaxOn/Assets.xcassets/Colors/Main Colors/RelaxLavender.colorset/Contents.json
+++ b/RelaxOn/Assets.xcassets/Colors/Main Colors/RelaxLavender.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBC",
+          "green" : "0xA1",
+          "red" : "0xC1"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBC",
+          "green" : "0xA1",
+          "red" : "0xC1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RelaxOn/Assets.xcassets/Colors/Main Colors/RelaxNightBlue.colorset/Contents.json
+++ b/RelaxOn/Assets.xcassets/Colors/Main Colors/RelaxNightBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB8",
+          "green" : "0x69",
+          "red" : "0x5F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB8",
+          "green" : "0x69",
+          "red" : "0x5F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RelaxOn/Assets.xcassets/Colors/Main Colors/RelaxRealBlack.colorset/Contents.json
+++ b/RelaxOn/Assets.xcassets/Colors/Main Colors/RelaxRealBlack.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RelaxOn/Assets.xcassets/Colors/System Colors/Contents.json
+++ b/RelaxOn/Assets.xcassets/Colors/System Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RelaxOn/Assets.xcassets/Colors/System Colors/SystemGrey1.colorset/Contents.json
+++ b/RelaxOn/Assets.xcassets/Colors/System Colors/SystemGrey1.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF2",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF2",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RelaxOn/Assets.xcassets/Colors/System Colors/SystemGrey2.colorset/Contents.json
+++ b/RelaxOn/Assets.xcassets/Colors/System Colors/SystemGrey2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x93",
+          "green" : "0x93",
+          "red" : "0x93"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x93",
+          "green" : "0x93",
+          "red" : "0x93"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RelaxOn/Assets.xcassets/Colors/System Colors/SystemGrey3.colorset/Contents.json
+++ b/RelaxOn/Assets.xcassets/Colors/System Colors/SystemGrey3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7D",
+          "green" : "0x7D",
+          "red" : "0x7D"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7D",
+          "green" : "0x7D",
+          "red" : "0x7D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RelaxOn/Utilities/Extension.swift
+++ b/RelaxOn/Utilities/Extension.swift
@@ -1,0 +1,20 @@
+//
+//  Extension.swift
+//  RelaxOn
+//
+//  Created by Minkyeong Ko on 2022/08/02.
+//
+
+import Foundation
+import SwiftUI
+
+extension Color {
+    static let relaxBlack = Color("RelaxBlack")
+    static let relaxRealBlack = Color("RelaxRealBlack")
+    static let relaxNightBlue = Color("RelaxNightBlue")
+    static let relaxLavender = Color("RelaxLavender")
+    static let relaxDimPurple = Color("RelaxDimPurple")
+    static let systemGrey1 = Color("SystemGrey1")
+    static let systemGrey2 = Color("SystemGrey2")
+    static let systemGrey3 = Color("SystemGrey3")
+}

--- a/RelaxOn/Utilities/Extension.swift
+++ b/RelaxOn/Utilities/Extension.swift
@@ -9,11 +9,13 @@ import Foundation
 import SwiftUI
 
 extension Color {
+    // Main Color
     static let relaxBlack = Color("RelaxBlack")
     static let relaxRealBlack = Color("RelaxRealBlack")
     static let relaxNightBlue = Color("RelaxNightBlue")
     static let relaxLavender = Color("RelaxLavender")
     static let relaxDimPurple = Color("RelaxDimPurple")
+    // System Color
     static let systemGrey1 = Color("SystemGrey1")
     static let systemGrey2 = Color("SystemGrey2")
     static let systemGrey3 = Color("SystemGrey3")

--- a/RelaxOn/Utilities/Extension.swift
+++ b/RelaxOn/Utilities/Extension.swift
@@ -5,7 +5,6 @@
 //  Created by Minkyeong Ko on 2022/08/02.
 //
 
-import Foundation
 import SwiftUI
 
 extension Color {


### PR DESCRIPTION
## 작업 내용 (Content)
- Figma의 Design System 페이지에 정의된 색상들을 Color Asset으로 추가하였습니다
- Color extension을 사용해 `.relaxBlack` -> 이런 식으로 코드로 커스텀 색상을 사용할 수 있도록 하였습니다

## 기타 사항 (Etc)
- [피그마 색상 설정 관련 디스커션 링크](https://github.com/M1zz/RelaxOn/discussions/130#discussion-4272714)
- 커스텀 색상인 SystemGrey를 추가하다가 우연히 Xcode 자체에 SystemGray가 있다는 것을 알게 되어서, 관련 내용을 담은 [디스커션 링크](https://github.com/M1zz/RelaxOn/discussions/131#discussion-4272728)를 첨부합니다 
- 색상을 사용할 때 `Color.relaxBlack` 이렇게 사용할 수도 있지만, `.foregroundColor(.relaxBlack)` 과 같이 Color 타입이 확실한 경우에는 Color를 생략하고 사용하실 수 있습니다
- 현재 컬러 팔레트가 Main, System 두 파트로 나눠지는데 바로 색상에 접근할 지, 카테고리로 접근할 지를 고민한 [디스커션 링크](https://github.com/M1zz/RelaxOn/discussions/132#discussion-4272774)를 첨부합니다
- 과거 LullabyRecipe의 잔재로 예전에 사용했던 Color Asset이 남아 있는데, 과거 LullabyRecipe들의 View 들을 삭제할 때 잊지 말고 꼭 함께 삭제해야 할 것 같습니다

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #107 

## 관련 사진(Optional)
<img width="532" alt="스크린샷 2022-08-02 오후 11 21 15" src="https://user-images.githubusercontent.com/78426896/182401705-4e14373a-75f2-44df-8dee-5f6e5b708d97.png">

