### PR TITLE
[feat] CDLibrary에서 사용자의 music을 삭제할 수 있도록 구현

### DIFF
--- a/RelaxOn/Manager/UserDefaultsManager.swift
+++ b/RelaxOn/Manager/UserDefaultsManager.swift
@@ -16,4 +16,5 @@ class UserDefaultsManager {
     let guest: String = "Guest"
     let recipes: String = "recipes"
     let notFirstVisit: String = "notFirstVisit"
+    let lastMusicId: String = "lastMusicId"
 }

--- a/RelaxOn/Model/DummyData.swift
+++ b/RelaxOn/Model/DummyData.swift
@@ -8,11 +8,33 @@
 import Foundation
 
 let dummyMixedSound = MixedSound(id: 0,
-                                 name: "test",
-                                 baseSound: dummyBaseSound,
-                                 melodySound: dummyMelodySound,
-                                 naturalSound: dummyNaturalSound,
+                                 name: "dummy0",
+                                 baseSound: baseSounds[1],
+                                 melodySound: melodySounds[1],
+                                 naturalSound: naturalSounds[1],
                                  imageName: "Recipe1")
+
+let dummyMixedSound1 = MixedSound(id: 1,
+                                  name: "dummy1",
+                                  baseSound: baseSounds[2],
+                                  melodySound: melodySounds[2],
+                                  naturalSound: naturalSounds[2],
+                                  imageName: "Recipe1")
+
+let dummyMixedSound2 = MixedSound(id: 2,
+                                  name: "dummy2",
+                                  baseSound: baseSounds[3],
+                                  melodySound: melodySounds[3],
+                                  naturalSound: naturalSounds[3],
+                                  imageName: "Recipe1")
+
+let dummyMixedSound3 = MixedSound(id: 3,
+                                  name: "dummy3",
+                                  baseSound: baseSounds[4],
+                                  melodySound: melodySounds[4],
+                                  naturalSound: naturalSounds[4],
+                                  imageName: "Recipe1")
+
 let dummyBaseSound = Sound(id: 0,
                            name: BaseAudioName.longSun.fileName,
                            soundType: .base,

--- a/RelaxOn/Model/MixedSound.swift
+++ b/RelaxOn/Model/MixedSound.swift
@@ -12,6 +12,14 @@ struct MixedSound: Identifiable, Codable, Equatable {
         return true
     }
     
+    /// 현재 라이브러리의 id 값에서 가장 큰 값에 + 1을 더한 값을 반환
+    static func getUniqueId() -> Int {
+        if let maxId = userRepositories.map({$0.id}).max() {
+            return maxId + 1
+        }
+        return 0
+    }
+
     let id: Int
     let name: String
     var baseSound: Sound?

--- a/RelaxOn/Model/MixedSound.swift
+++ b/RelaxOn/Model/MixedSound.swift
@@ -12,12 +12,12 @@ struct MixedSound: Identifiable, Codable, Equatable {
         return true
     }
     
-    /// 현재 라이브러리의 id 값에서 가장 큰 값에 + 1을 더한 값을 반환
+    /// 마지막으로 생성된 id + 1 값을 반환
     static func getUniqueId() -> Int {
-        if let maxId = userRepositories.map({$0.id}).max() {
-            return maxId + 1
-        }
-        return 0
+        let lastMusicId = UserDefaultsManager.shared.standard.integer(forKey: UserDefaultsManager.shared.lastMusicId)
+        let returnId = lastMusicId + 1
+        UserDefaultsManager.shared.standard.set(returnId, forKey: UserDefaultsManager.shared.lastMusicId)
+        return returnId
     }
 
     let id: Int

--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -14,6 +14,8 @@ struct CDListView: View {
         melody: "",
         natural: ""
     )
+    @State var isEditMode = false
+    @State var selectedMixedSoundId: [Int] = []
     
     var body: some View {
         
@@ -25,6 +27,11 @@ struct CDListView: View {
                     plusCDImage
                     ForEach(userRepositoriesState.reversed()){ mixedSound in
                         CDCardView(data: mixedSound, audioVolumes: (baseVolume: mixedSound.baseSound?.audioVolume ?? 1.0, melodyVolume: mixedSound.melodySound?.audioVolume ?? 1.0, naturalVolume: mixedSound.naturalSound?.audioVolume ?? 1.0))
+                            .disabled(isEditMode)
+                            .onTapGesture {
+                                print("\(mixedSound.id)")
+                            }
+    
                     }
                 }
             }
@@ -67,11 +74,17 @@ struct CDListView: View {
             Spacer()
             
             Button(action: {
-                
+                isEditMode.toggle()
             }) {
-                Text("Edit")
-                    .foregroundColor(Color.gray)
-                    .font(.system(size: 17))
+                if selectedMixedSoundId.isEmpty {
+                    Text(isEditMode ? "Done" : "Edit")
+                        .foregroundColor(Color.gray)
+                        .font(.system(size: 17))
+                } else {
+                    Text("Delete")
+                        .foregroundColor(.red)
+                        .font(.system(size: 17))
+                }
             }
         }
     }

--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -34,14 +34,14 @@ struct CDListView: View {
                                     if selectedMixedSoundIds.firstIndex(where: {$0 == mixedSound.id}) != nil {
                                         Image(systemName: "checkmark.circle.fill")
                                             .foregroundColor(.white)
-                                            .padding(.bottom, LayoutConstants.pading.bottomOfRadioButton)
-                                            .padding(.trailing, LayoutConstants.pading.trailingOfRadioButton)
+                                            .padding(.bottom, LayoutConstants.padding.bottomOfRadioButton)
+                                            .padding(.trailing, LayoutConstants.padding.trailingOfRadioButton)
                                     } else {
                                         Image(systemName: "circle")
                                             .foregroundColor(.white)
                                             .background(Image(systemName: "circle.fill").foregroundColor(.gray).opacity(0.5))
-                                            .padding(.bottom, LayoutConstants.pading.bottomOfRadioButton)
-                                            .padding(.trailing, LayoutConstants.pading.trailingOfRadioButton)
+                                            .padding(.bottom, LayoutConstants.padding.bottomOfRadioButton)
+                                            .padding(.trailing, LayoutConstants.padding.trailingOfRadioButton)
                                     }
                                 }
                             }
@@ -135,7 +135,7 @@ struct CDListView: View {
 
 extension CDListView {
     private struct LayoutConstants {
-        enum pading {
+        enum padding {
             static let trailingOfRadioButton: CGFloat = 10
             static let bottomOfRadioButton: CGFloat = 40
         }

--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+
+
 struct CDListView: View {
     @State var userRepositoriesState: [MixedSound] = userRepositories
     @State var selectedImageNames = (
@@ -15,23 +17,43 @@ struct CDListView: View {
         natural: ""
     )
     @State var isEditMode = false
-    @State var selectedMixedSoundId: [Int] = []
+    @State var selectedMixedSoundIds: [Int] = []
     
     var body: some View {
         
         VStack {
             libraryHeader
-            
             ScrollView(.vertical, showsIndicators: false) {
                 LazyVGrid(columns: Array(repeating: GridItem(.flexible(),spacing: 10), count: 2), spacing: 20) {
                     plusCDImage
                     ForEach(userRepositoriesState.reversed()){ mixedSound in
                         CDCardView(data: mixedSound, audioVolumes: (baseVolume: mixedSound.baseSound?.audioVolume ?? 1.0, melodyVolume: mixedSound.melodySound?.audioVolume ?? 1.0, naturalVolume: mixedSound.naturalSound?.audioVolume ?? 1.0))
                             .disabled(isEditMode)
-                            .onTapGesture {
-                                print("\(mixedSound.id)")
+                            .overlay(alignment : .bottomTrailing) {
+                                if isEditMode {
+                                    if selectedMixedSoundIds.firstIndex(where: {$0 == mixedSound.id}) != nil {
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .foregroundColor(.white)
+                                            .padding(.bottom, LayoutConstants.pading.bottomOfRadioButton)
+                                            .padding(.trailing, LayoutConstants.pading.trailingOfRadioButton)
+                                    } else {
+                                        Image(systemName: "circle")
+                                            .foregroundColor(.white)
+                                            .background(Image(systemName: "circle.fill").foregroundColor(.gray).opacity(0.5))
+                                            .padding(.bottom, LayoutConstants.pading.bottomOfRadioButton)
+                                            .padding(.trailing, LayoutConstants.pading.trailingOfRadioButton)
+                                    }
+                                }
                             }
-    
+                            .onTapGesture {
+                                if isEditMode {
+                                    if let index = selectedMixedSoundIds.firstIndex(where: {$0 == mixedSound.id}) {
+                                        selectedMixedSoundIds.remove(at: index)
+                                    } else {
+                                        selectedMixedSoundIds.append(mixedSound.id)
+                                    }
+                                }
+                            }
                     }
                 }
             }
@@ -74,9 +96,14 @@ struct CDListView: View {
             Spacer()
             
             Button(action: {
-                isEditMode.toggle()
+                if selectedMixedSoundIds.isEmpty {
+                    isEditMode.toggle()
+                } else {
+                    print("hello")
+                    print(selectedMixedSoundIds)
+                }
             }) {
-                if selectedMixedSoundId.isEmpty {
+                if selectedMixedSoundIds.isEmpty {
                     Text(isEditMode ? "Done" : "Edit")
                         .foregroundColor(Color.gray)
                         .font(.system(size: 17))
@@ -106,8 +133,57 @@ struct CDListView: View {
     }
 }
 
+extension CDListView {
+    private struct LayoutConstants {
+        enum pading {
+            static let trailingOfRadioButton: CGFloat = 10
+            static let bottomOfRadioButton: CGFloat = 40
+        }
+    }
+}
+
 struct CDListView_Previews: PreviewProvider {
+    struct dummy {
+        static let MixedSound1 = MixedSound(id: 0,
+                                         name: "test",
+                                         baseSound: dummyBaseSound,
+                                         melodySound: dummyMelodySound,
+                                         naturalSound: dummyNaturalSound,
+                                         imageName: "Recipe1")
+        
+        static let MixedSound2 = MixedSound(id: 1,
+                                         name: "test2",
+                                         baseSound: dummyBaseSound,
+                                         melodySound: dummyMelodySound,
+                                         naturalSound: dummyNaturalSound,
+                                         imageName: "Recipe2")
+        
+        static let MixedSound3 = MixedSound(id: 2,
+                                         name: "test3",
+                                         baseSound: dummyBaseSound,
+                                         melodySound: dummyMelodySound,
+                                         naturalSound: dummyNaturalSound,
+                                         imageName: "Recipe3")
+        
+        static let dummyBaseSound = Sound(id: 0,
+                                   name: BaseAudioName.longSun.fileName,
+                                   soundType: .base,
+                                   audioVolume: 0.8,
+                                   imageName: "LongSun")
+
+        static let dummyMelodySound = Sound(id: 2,
+                                     name: MelodyAudioName.ambient.fileName,
+                                     soundType: .melody,
+                                     audioVolume: 1.0,
+                                     imageName: "Melody1")
+
+        static let dummyNaturalSound = Sound(id: 6,
+                                      name: NaturalAudioName.dryGrass.fileName,
+                                      soundType: .natural,
+                                      audioVolume: 0.4,
+                                      imageName: "field")
+    }
     static var previews: some View {
-        CDListView()
+        CDListView(userRepositoriesState: [dummy.MixedSound1, dummy.MixedSound2, dummy.MixedSound3])
     }
 }

--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -26,7 +26,7 @@ struct CDListView: View {
             libraryHeader
             ScrollView(.vertical, showsIndicators: false) {
                 LazyVGrid(columns: Array(repeating: GridItem(.flexible(),spacing: 10), count: 2), spacing: 20) {
-                    plusCDImage
+                    plusCDImage.disabled(isEditMode)
                     ForEach(userRepositoriesState.reversed()){ mixedSound in
                         CDCardView(data: mixedSound, audioVolumes: (baseVolume: mixedSound.baseSound?.audioVolume ?? 1.0, melodyVolume: mixedSound.melodySound?.audioVolume ?? 1.0, naturalVolume: mixedSound.naturalSound?.audioVolume ?? 1.0))
                             .disabled(isEditMode)

--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -34,14 +34,14 @@ struct CDListView: View {
                                     if selectedMixedSoundIds.firstIndex(where: {$0 == mixedSound.id}) != nil {
                                         Image(systemName: "checkmark.circle.fill")
                                             .foregroundColor(.white)
-                                            .padding(.bottom, LayoutConstants.padding.bottomOfRadioButton)
-                                            .padding(.trailing, LayoutConstants.padding.trailingOfRadioButton)
+                                            .padding(.bottom, LayoutConstants.Padding.bottomOfRadioButton)
+                                            .padding(.trailing, LayoutConstants.Padding.trailingOfRadioButton)
                                     } else {
                                         Image(systemName: "circle")
                                             .foregroundColor(.white)
                                             .background(Image(systemName: "circle.fill").foregroundColor(.gray).opacity(0.5))
-                                            .padding(.bottom, LayoutConstants.padding.bottomOfRadioButton)
-                                            .padding(.trailing, LayoutConstants.padding.trailingOfRadioButton)
+                                            .padding(.bottom, LayoutConstants.Padding.bottomOfRadioButton)
+                                            .padding(.trailing, LayoutConstants.Padding.trailingOfRadioButton)
                                     }
                                 }
                             }
@@ -161,7 +161,7 @@ struct CDListView: View {
 
 extension CDListView {
     private struct LayoutConstants {
-        enum padding {
+        enum Padding {
             static let trailingOfRadioButton: CGFloat = 10
             static let bottomOfRadioButton: CGFloat = 40
         }

--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -14,9 +14,9 @@ struct CDListView: View {
         melody: "",
         natural: ""
     )
-    @State var isEditMode = false
-    @State var selectedMixedSoundIds: [Int] = []
-    @State var showingActionSheet = false
+    @State private var isEditMode = false
+    @State private var selectedMixedSoundIds: [Int] = []
+    @State private var showingActionSheet = false
     
     var body: some View {
         

--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -76,7 +76,6 @@ struct CDListView: View {
             if let data = UserDefaultsManager.shared.standard.data(forKey: UserDefaultsManager.shared.recipes) {
                 do {
                     let decoder = JSONDecoder()
-
                     userRepositories = try decoder.decode([MixedSound].self, from: data)
                     userRepositoriesState = userRepositories
                     print("help : \(userRepositories)")
@@ -170,47 +169,10 @@ extension CDListView {
 }
 
 struct CDListView_Previews: PreviewProvider {
-    struct dummy {
-        static let MixedSound1 = MixedSound(id: 0,
-                                         name: "test",
-                                         baseSound: dummyBaseSound,
-                                         melodySound: dummyMelodySound,
-                                         naturalSound: dummyNaturalSound,
-                                         imageName: "Recipe1")
-        
-        static let MixedSound2 = MixedSound(id: 1,
-                                         name: "test2",
-                                         baseSound: dummyBaseSound,
-                                         melodySound: dummyMelodySound,
-                                         naturalSound: dummyNaturalSound,
-                                         imageName: "Recipe2")
-        
-        static let MixedSound3 = MixedSound(id: 2,
-                                         name: "test3",
-                                         baseSound: dummyBaseSound,
-                                         melodySound: dummyMelodySound,
-                                         naturalSound: dummyNaturalSound,
-                                         imageName: "Recipe3")
-        
-        static let dummyBaseSound = Sound(id: 0,
-                                   name: BaseAudioName.longSun.fileName,
-                                   soundType: .base,
-                                   audioVolume: 0.8,
-                                   imageName: "LongSun")
-
-        static let dummyMelodySound = Sound(id: 2,
-                                     name: MelodyAudioName.ambient.fileName,
-                                     soundType: .melody,
-                                     audioVolume: 1.0,
-                                     imageName: "Melody1")
-
-        static let dummyNaturalSound = Sound(id: 6,
-                                      name: NaturalAudioName.dryGrass.fileName,
-                                      soundType: .natural,
-                                      audioVolume: 0.4,
-                                      imageName: "field")
-    }
     static var previews: some View {
-        CDListView(userRepositoriesState: [dummy.MixedSound1, dummy.MixedSound2, dummy.MixedSound3])
+        NavigationView {
+            CDListView(userRepositoriesState: [dummyMixedSound, dummyMixedSound1, dummyMixedSound2, dummyMixedSound3])
+                .navigationBarHidden(true)
+        }
     }
 }

--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-
-
 struct CDListView: View {
     @State var userRepositoriesState: [MixedSound] = userRepositories
     @State var selectedImageNames = (
@@ -24,6 +22,7 @@ struct CDListView: View {
         
         VStack {
             libraryHeader
+            
             ScrollView(.vertical, showsIndicators: false) {
                 LazyVGrid(columns: Array(repeating: GridItem(.flexible(),spacing: 10), count: 2), spacing: 20) {
                     plusCDImage.disabled(isEditMode)
@@ -76,6 +75,7 @@ struct CDListView: View {
             if let data = UserDefaultsManager.shared.standard.data(forKey: UserDefaultsManager.shared.recipes) {
                 do {
                     let decoder = JSONDecoder()
+                    
                     userRepositories = try decoder.decode([MixedSound].self, from: data)
                     userRepositoriesState = userRepositories
                     print("help : \(userRepositories)")

--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -18,6 +18,7 @@ struct CDListView: View {
     )
     @State var isEditMode = false
     @State var selectedMixedSoundIds: [Int] = []
+    @State var showingActionSheet = false
     
     var body: some View {
         
@@ -85,7 +86,34 @@ struct CDListView: View {
                 }
             }
         }
-        
+        .confirmationDialog("Are you sure?",
+                            isPresented: $showingActionSheet) {
+            Button("Delete \(selectedMixedSoundIds.count) CDs", role: .destructive) {
+                selectedMixedSoundIds.forEach { id in
+                    if let index = userRepositories.firstIndex(where: {$0.id == id}) {
+                        userRepositories.remove(at: index)
+                    }
+                }
+                let data = getEncodedData(data: userRepositories)
+                UserDefaults.standard.set(data, forKey: "recipes")
+                selectedMixedSoundIds = []
+                isEditMode = false
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("These CDs will be deleted from your library")
+        }
+    }
+    
+    private func getEncodedData(data: [MixedSound]) -> Data? {
+        do {
+            let encoder = JSONEncoder()
+            let encodedData = try encoder.encode(data)
+            return encodedData
+        } catch {
+            print("Unable to Encode Note (\(error))")
+        }
+        return nil
     }
     
     var libraryHeader: some View {
@@ -99,8 +127,7 @@ struct CDListView: View {
                 if selectedMixedSoundIds.isEmpty {
                     isEditMode.toggle()
                 } else {
-                    print("hello")
-                    print(selectedMixedSoundIds)
+                    showingActionSheet = true
                 }
             }) {
                 if selectedMixedSoundIds.isEmpty {

--- a/RelaxOn/Views/Kitchen/CustomAlertView.swift
+++ b/RelaxOn/Views/Kitchen/CustomAlertView.swift
@@ -45,7 +45,7 @@ struct CustomAlertView: View {
 
                     Button {
                         // TODO: - id 문제 해결
-                        let newSound = MixedSound(id: makeMusicId(ids: userRepositories.map({$0.id})),
+                        let newSound = MixedSound(id: MixedSound.getUniqueId(),
                                                   name: textEntered,
                                                   baseSound: baseSound,
                                                   melodySound: melodySound,
@@ -70,19 +70,6 @@ struct CustomAlertView: View {
             }.padding(.top, 40)
         }
         .frame(width: deviceFrame().screenWidth - 100 , height: deviceFrame().screenHeight - 620)
-    }
-    
-    /// 현재 라이브러리의 id 값에서 비어 있는 숫자 중 가장 작은 값을 반환
-    /// ex) 현재 라이브러리의 id 값이 [0, 2, 3]일 경우 새로운 id 값으로 1을 반환
-    private func makeMusicId(ids: [Int]) -> Int {
-        for i in 0..<ids.count {
-            if ids.first(where: {$0 == i}) == nil {
-                return i
-            } else {
-                continue
-            }
-        }
-        return ids.count
     }
     
     private func getEncodedData(data: [MixedSound]) -> Data? {

--- a/RelaxOn/Views/Kitchen/CustomAlertView.swift
+++ b/RelaxOn/Views/Kitchen/CustomAlertView.swift
@@ -45,7 +45,7 @@ struct CustomAlertView: View {
 
                     Button {
                         // TODO: - id 문제 해결
-                        let newSound = MixedSound(id: userRepositories.count,
+                        let newSound = MixedSound(id: getMusicId(ids: userRepositories.map({$0.id})),
                                                   name: textEntered,
                                                   baseSound: baseSound,
                                                   melodySound: melodySound,
@@ -70,6 +70,17 @@ struct CustomAlertView: View {
             }.padding(.top, 40)
         }
         .frame(width: deviceFrame().screenWidth - 100 , height: deviceFrame().screenHeight - 620)
+    }
+    
+    private func getMusicId(ids: [Int]) -> Int {
+        for i in 0..<ids.count {
+            if ids.first(where: {$0 == i}) == nil {
+                return i
+            } else {
+                continue
+            }
+        }
+        return ids.count
     }
     
     private func getEncodedData(data: [MixedSound]) -> Data? {

--- a/RelaxOn/Views/Kitchen/CustomAlertView.swift
+++ b/RelaxOn/Views/Kitchen/CustomAlertView.swift
@@ -45,7 +45,7 @@ struct CustomAlertView: View {
 
                     Button {
                         // TODO: - id 문제 해결
-                        let newSound = MixedSound(id: getMusicId(ids: userRepositories.map({$0.id})),
+                        let newSound = MixedSound(id: makeMusicId(ids: userRepositories.map({$0.id})),
                                                   name: textEntered,
                                                   baseSound: baseSound,
                                                   melodySound: melodySound,
@@ -72,7 +72,9 @@ struct CustomAlertView: View {
         .frame(width: deviceFrame().screenWidth - 100 , height: deviceFrame().screenHeight - 620)
     }
     
-    private func getMusicId(ids: [Int]) -> Int {
+    /// 현재 라이브러리의 id 값에서 비어 있는 숫자 중 가장 작은 값을 반환
+    /// ex) 현재 라이브러리의 id 값이 [0, 2, 3]일 경우 새로운 id 값으로 1을 반환
+    private func makeMusicId(ids: [Int]) -> Int {
         for i in 0..<ids.count {
             if ids.first(where: {$0 == i}) == nil {
                 return i


### PR DESCRIPTION
## 작업 내용 (Content)
- CDLibrary에서 사용자의 music을 삭제할 수 있도록 구현 
  - music의 id가 유일하다는 가정하에 로직이 동작함. 
  - 기존 studioView에서 새로은 music을 생성시 id가 겹칠 수 있어서, id 생성 로직 변경
  - edit 상태일 때는 CDListView 내부의 NavigationLink가 동작하지 않도록 설정
- preview에서 사용할 더미데이터 추가, 수정

https://user-images.githubusercontent.com/59302419/183242141-efbcaac2-356a-46c6-9fac-2e202e05fe70.mov

## 기타 사항 (Etc)
### 주요 리뷰어
- @Minkyeong-Ko : CDListVIew를 수정함
- @M1zz @Kim-Yeon-ho  : id 생성 로직 변경함(studioView)
- @ccdkk : id 생성 로직 변경(remoteController에서 이전, 다음 곡 재생시 id를 기준으로 작동)

### 나중에 해야할 일
- font style 확정시 font 변경
- music 삭제하면 애니메이션으로 부드럽게 재배치 할 수 있도록 변경
- CDCardView() 밑에 붙어있는 .disabled().overlay().onTapGesture() modifier를 모듈화시키기

