### PR TITLE
[Feat] Preview 여러개 볼 수 있도록 구현

### DIFF
--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		CCA7F51E2877501E00D6A239 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = CCA7F5202877501E00D6A239 /* Localizable.strings */; };
 		E211ED052896D051002843EE /* MusicTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E211ED042896D051002843EE /* MusicTimer.swift */; };
 		E211ED072896D06A002843EE /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E211ED062896D06A002843EE /* TimerManager.swift */; };
+		E24F21E228ABE1A100371BA4 /* MultiPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24F21E128ABE1A000371BA4 /* MultiPreview.swift */; };
 		E2BF105428914E9E00408B8C /* TimerNavigationLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BF105328914E9E00408B8C /* TimerNavigationLinkView.swift */; };
 		E2BF1057289173F100408B8C /* TimerPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BF1056289173F100408B8C /* TimerPickerView.swift */; };
 		E2BF105928917B6000408B8C /* TempMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BF105828917B6000408B8C /* TempMainView.swift */; };
@@ -240,6 +241,7 @@
 		CCF0D9882887748500F61495 /* CustomTabView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomTabView.swift; sourceTree = "<group>"; };
 		E211ED042896D051002843EE /* MusicTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicTimer.swift; sourceTree = "<group>"; };
 		E211ED062896D06A002843EE /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
+		E24F21E128ABE1A000371BA4 /* MultiPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiPreview.swift; sourceTree = "<group>"; };
 		E2BF105328914E9E00408B8C /* TimerNavigationLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerNavigationLinkView.swift; sourceTree = "<group>"; };
 		E2BF1056289173F100408B8C /* TimerPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerPickerView.swift; sourceTree = "<group>"; };
 		E2BF105828917B6000408B8C /* TempMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempMainView.swift; sourceTree = "<group>"; };
@@ -380,6 +382,7 @@
 				CCA7F5202877501E00D6A239 /* Localizable.strings */,
 				CC2820472880102400587334 /* ViewModifiers.swift */,
 				21FE2BB72899606A0024DA92 /* Extension.swift */,
+				E24F21E128ABE1A000371BA4 /* MultiPreview.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -730,6 +733,7 @@
 				CC5AC191289D69E500FE847B /* WidgetManager.swift in Sources */,
 				58DE61852839C13900F25769 /* CdLibraryView.swift in Sources */,
 				58DE1032283DF6E7002CDB9F /* Static.swift in Sources */,
+				E24F21E228ABE1A100371BA4 /* MultiPreview.swift in Sources */,
 				58DE61AF283A8C8B00F25769 /* KitchenView.swift in Sources */,
 				21D3ED952892774F006E871F /* UserDefaultsManager.swift in Sources */,
 				219BD67328900A28006FAF55 /* CDListView.swift in Sources */,

--- a/RelaxOn/Utilities/MultiPreview.swift
+++ b/RelaxOn/Utilities/MultiPreview.swift
@@ -1,0 +1,35 @@
+//
+//  MultiPreview.swift
+//  RelaxOn
+//
+//  Created by hyo on 2022/08/16.
+//
+
+import SwiftUI
+
+struct MultiPreview<V: View>: View {
+    let content: () -> V
+        
+    var body: some View {
+        content()
+            .previewDevice("iPhone 13")
+            .environment(\.locale, .init(identifier: "en"))
+        content()
+            .previewDevice("iPhone 13")
+            .environment(\.locale, .init(identifier: "ko"))
+        content()
+            .previewDevice("iPhone SE (3rd generation)")
+            .environment(\.locale, .init(identifier: "en"))
+        content()
+            .previewDevice("iPhone SE (3rd generation)")
+            .environment(\.locale, .init(identifier: "ko"))
+    }
+}
+
+struct Preview_Previews: PreviewProvider {
+    static var previews: some View {
+        MultiPreview {
+            Text("베이스")
+        }
+    }
+}

--- a/RelaxOn/Views/Home/CdLibraryView.swift
+++ b/RelaxOn/Views/Home/CdLibraryView.swift
@@ -60,7 +60,9 @@ struct CdLibraryView: View {
 
 struct CdLibraryView_Previews: PreviewProvider {
     static var previews: some View {
-        CdLibraryView()
+        MultiPreview {
+            CdLibraryView()
+        }
     }
 }
 


### PR DESCRIPTION
## 작업 내용 (Content)
- 기기 사이즈 호환, 다국어 지원이 잘 적용됐는지를 확인하기 위해서 preview에서 한번에 볼 수 있도록 MultiPreview를 구현
- 총 4가지 preview를 한번에 볼 수 있음
<img width="300" alt="image" src="https://user-images.githubusercontent.com/59302419/184914372-5bd43b80-2c42-4e08-8835-4fc8c0d642d9.png">
<img width="696" alt="image" src="https://user-images.githubusercontent.com/59302419/184916921-979b0ff3-9135-4566-986e-ca3c220f1af3.png">


## 사용 방법
- 기존 preview 코드에 MultiPreview를 씌어주면 된다. 

<img width="898" alt="image" src="https://user-images.githubusercontent.com/59302419/184916470-f500d192-917e-4b74-8d9a-60012f4e3916.png">
 


