### PR TITLE
[Feat] #171 스튜디오 뷰 내, 볼륨 조절 및 기타 에러 수정

### DIFF
--- a/RelaxOn/Views/Kitchen/SelectedImageView.swift
+++ b/RelaxOn/Views/Kitchen/SelectedImageView.swift
@@ -31,7 +31,7 @@ struct SelectedImageView: View {
             IllustImage(imageName: selectedImageNames.melody, animateVar: opacityAnimationValues[1])
                 .blendMode(.darken)
             
-            // Natural
+            // WhiteNoise
             IllustImage(imageName: selectedImageNames.whiteNoise, animateVar: opacityAnimationValues[2])
         }
     }

--- a/RelaxOn/Views/Kitchen/StudioView.swift
+++ b/RelaxOn/Views/Kitchen/StudioView.swift
@@ -106,13 +106,13 @@ struct StudioView: View {
                 }
                 .frame(height: 25)
                 .onChange(of: volumes[0]) { volume in
-                    baseAudioManager.changeVolume(track: selectedBaseSound.name, volume: volume)
+                    baseAudioManager.changeVolume(track: selectedBaseSound.imageName, volume: volume)
                 }
                 .onChange(of: volumes[1]) { volume in
-                    whiteNoiseAudioManager.changeVolume(track: selectedWhiteNoiseSound.name, volume: volume)
+                    melodyAudioManager.changeVolume(track: selectedMelodySound.imageName, volume: volume)
                 }
                 .onChange(of: volumes[2]) { volume in
-                    melodyAudioManager.changeVolume(track: selectedMelodySound.name, volume: volume)
+                    whiteNoiseAudioManager.changeVolume(track: selectedWhiteNoiseSound.imageName, volume: volume)
                 }
                 
                 Text("\(Int(volumes[select] * 100))")
@@ -137,25 +137,10 @@ struct StudioView: View {
                                 
                                 opacityAnimationValues[0] = 0.0
                             } else {
-                                baseAudioManager.startPlayer(track: selectedBaseSound.name, volume: volumes[select])
+                                baseAudioManager.startPlayer(track: selectedBaseSound.imageName, volume: volumes[select])
                                 
                                 selectedImageNames.base = "BaseIllust"
                                 opacityAnimationValues[0] = 1
-                            }
-                        }
-                    case .whiteNoise:
-                        RadioButtonGroupView(selectedId: soundType.rawValue,
-                                             items: whiteNoiseSounds) { whiteNoiseSounds in
-                            selectedWhiteNoiseSound = whiteNoiseSounds
-                            
-                            if selectedWhiteNoiseSound.name == "Empty" {
-                                whiteNoiseAudioManager.stop()
-                                
-                                opacityAnimationValues[2] = 0.0
-                            } else {
-                                whiteNoiseAudioManager.startPlayer(track: selectedWhiteNoiseSound.name, volume: volumes[select])
-                                selectedImageNames.whiteNoise = ""//selectedWhiteNoiseSound.imageName                                
-                                opacityAnimationValues[2] = 0.5
                             }
                         }
                     case .melody:
@@ -168,11 +153,26 @@ struct StudioView: View {
                                 
                                 opacityAnimationValues[1] = 0.0
                             } else {
-                                melodyAudioManager.startPlayer(track: selectedMelodySound.name, volume: volumes[select])
+                                melodyAudioManager.startPlayer(track: selectedMelodySound.imageName, volume: volumes[select])
                                 
                                 selectedImageNames.melody = "MelodyIllust"
-                                
                                 opacityAnimationValues[1] = 1
+                            }
+                        }
+                    case .whiteNoise:
+                        RadioButtonGroupView(selectedId: soundType.rawValue,
+                                             items: whiteNoiseSounds) { whiteNoiseSounds in
+                            selectedWhiteNoiseSound = whiteNoiseSounds
+                            
+                            if selectedWhiteNoiseSound.name == "Empty" {
+                                whiteNoiseAudioManager.stop()
+                                
+                                opacityAnimationValues[2] = 0.0
+                            } else {
+                                whiteNoiseAudioManager.startPlayer(track: selectedWhiteNoiseSound.imageName, volume: volumes[select])
+                                
+                                selectedImageNames.whiteNoise = ""//selectedWhiteNoiseSound.imageName
+                                opacityAnimationValues[2] = 0.5
                             }
                         }
                     }


### PR DESCRIPTION
## 작업 내용 (Content)
스튜디오 뷰에서
- 재생이 되지 않는 음원들 해결
- 화이트노이즈의 볼륨이 잘 되지 않는 것을 해결

## 기타 사항 (Etc)
- 기존에 Sound의 displayName에 띄어쓰기가 들어가, 음원 파일을 찾지 못하였습니다. 따라서 띄어쓰기가 없는 imageName으로 AudioManager를 실행시켰습니다.
- 멜로디와 백색소음 위치가 바뀌면서, natural에서 whiteNoise로 변수명이 변경되면서, 에러가 있었습니다. 순서와 변수명을 수정하여 해결하였습니다.

## Close Issues
Close #171

## 관련 사진(Optional)
