### PR TITLE
[Fix] empty Sound의 이미지 노출 수정

### DIFF
--- a/RelaxOn/Views/Home/CDCardView.swift
+++ b/RelaxOn/Views/Home/CDCardView.swift
@@ -20,18 +20,24 @@ struct CDCardView: View {
                 self.isShwoingMusicView.toggle()
             }, label: {
                     ZStack {
-                        Image(data.baseSound?.imageName ?? "")
-                            .resizable()
-                            .opacity(0.5)
-                            .frame(width: UIScreen.main.bounds.width * 0.43, height: UIScreen.main.bounds.width * 0.43)
-                        Image(data.melodySound?.imageName ?? "")
-                            .resizable()
-                            .opacity(0.5)
-                            .frame(width: UIScreen.main.bounds.width * 0.43, height: UIScreen.main.bounds.width * 0.43)
-                        Image(data.whiteNoiseSound?.imageName ?? "")
-                            .resizable()
-                            .opacity(0.5)
-                            .frame(width: UIScreen.main.bounds.width * 0.43, height: UIScreen.main.bounds.width * 0.43)
+                        if let baseSoundImageName = data.baseSound?.imageName {
+                            Image(baseSoundImageName)
+                                .resizable()
+                                .opacity(baseSoundImageName == "music" ? 0 : 0.5)
+                                .frame(width: UIScreen.main.bounds.width * 0.43, height: UIScreen.main.bounds.width * 0.43)
+                        }
+                        if let melodySoundImageName = data.melodySound?.imageName {
+                            Image(melodySoundImageName)
+                                .resizable()
+                                .opacity(melodySoundImageName == "music" ? 0 : 0.5)
+                                .frame(width: UIScreen.main.bounds.width * 0.43, height: UIScreen.main.bounds.width * 0.43)
+                        }
+                        if let whiteNoiseSoundImageName = data.whiteNoiseSound?.imageName {
+                            Image(whiteNoiseSoundImageName)
+                                .resizable()
+                                .opacity(whiteNoiseSoundImageName == "music" ? 0 : 0.5)
+                                .frame(width: UIScreen.main.bounds.width * 0.43, height: UIScreen.main.bounds.width * 0.43)
+                        }
                     }
                     .fullScreenCover(item: $selectedMixedSound) { _ in
                         NewMusicView(data: data, userRepositoriesState: $userRepositoriesState)

--- a/RelaxOn/Views/Home/Music/NewMusicView.swift
+++ b/RelaxOn/Views/Home/Music/NewMusicView.swift
@@ -213,18 +213,33 @@ extension NewMusicView {
     @ViewBuilder
     func CDCoverView() -> some View {
         ZStack {
-            Image(viewModel.mixedSound?.baseSound?.imageName ?? "")
-                .resizable()
-                .opacity(0.5)
-                .frame(width: .infinity, height: .infinity)
-            Image(viewModel.mixedSound?.melodySound?.imageName ?? "")
-                .resizable()
-                .opacity(0.5)
-                .frame(width: .infinity, height: .infinity)
-            Image(viewModel.mixedSound?.whiteNoiseSound?.imageName ?? "")
-                .resizable()
-                .opacity(0.5)
-                .frame(width: .infinity, height: .infinity)
+            if let baseSoundImageName = viewModel.mixedSound?.baseSound?.imageName {
+                    Image(baseSoundImageName)
+                        .resizable()
+                        .opacity(baseSoundImageName == "music" ? 0.0 : 0.5)
+                        .frame(width: .infinity, height: .infinity)
+            }
+            if let melodySoundImageName = viewModel.mixedSound?.melodySound?.imageName {
+                    Image(melodySoundImageName)
+                        .resizable()
+                        .opacity(melodySoundImageName == "music" ? 0.0 : 0.5)
+                        .frame(width: .infinity, height: .infinity)
+            }
+            if let whiteNoiseSoundImageName = viewModel.mixedSound?.whiteNoiseSound?.imageName {
+                let _ = print(whiteNoiseSoundImageName, "왜")
+                    Image(whiteNoiseSoundImageName)
+                        .resizable()
+                        .opacity(whiteNoiseSoundImageName == "music" ? 0.0 : 0.5)
+                        .frame(width: .infinity, height: .infinity)
+            }
+//            Image(viewModel.mixedSound?.melodySound?.imageName ?? "")
+//                .resizable()
+//                .opacity(0.5)
+//                .frame(width: .infinity, height: .infinity)
+//            Image(viewModel.mixedSound?.whiteNoiseSound?.imageName ?? "")
+//                .resizable()
+//                .opacity(0.5)
+//                .frame(width: .infinity, height: .infinity)
         }
     }
     


### PR DESCRIPTION
## 작업 내용 (Content)
- whiteNoise, melody, base 요소가 Empty로 설정되었을 때 "music"이미지 네임이 설정되는데 해당 경우에 music 이미지가 노출되는 현상을 수정하였습니다.

## 기타 사항 (Etc)
- 투명도 0.0을 줌으로써 해결했는데 empty인 경우 이미지를 주고싶지 않으면 어떻게 해야 할까요?

## Close Issues
Close #197 

## 관련 사진(Optional)
<img src="https://user-images.githubusercontent.com/91456952/187053603-0dcdadad-d011-430d-913a-b9998e444338.png" width="390" height="840"/>
<img src="https://user-images.githubusercontent.com/91456952/187053609-12ff0dce-6ecb-445d-a132-8615f6bd1cfd.png" width="390" height="840"/>

