### PR TITLE
[fix] Release 브랜치 에러 및 MusicView에서 볼륨 변경시 닫히는 오류 해결

### DIFF
--- a/RelaxOn/Views/Home/CdLibraryView.swift
+++ b/RelaxOn/Views/Home/CdLibraryView.swift
@@ -40,7 +40,6 @@ struct CdLibraryView: View {
                }
         }
         .fullScreenCover(isPresented: $showOnboarding, onDismiss: {
-            print("닫힘")
             userRepositoriesData = userRepositories
         } ,content: {
             OnboardingView(showOnboarding: $showOnboarding)

--- a/RelaxOn/Views/Home/Music/MusicViewModel.swift
+++ b/RelaxOn/Views/Home/Music/MusicViewModel.swift
@@ -44,9 +44,9 @@ final class MusicViewModel: NSObject, ObservableObject {
         // FIXME: addMainSoundToWidget()를 Sound가 재정렬 되었을 때 제일 위의 음악을 넣어야 합니다. (해당 로직이 안 짜진 거 같아 우선은, 여기로 뒀습니다.)
         didSet {
             if let mixedSound = mixedSound,
-               let baseImageName = mixedSound.baseSound?.imageName,
-               let melodyImageName = mixedSound.melodySound?.imageName,
-               let whiteNoiseImageName = mixedSound.whiteNoiseSound?.imageName {
+               let baseImageName = mixedSound.baseSound?.fileName,
+               let melodyImageName = mixedSound.melodySound?.fileName,
+               let whiteNoiseImageName = mixedSound.whiteNoiseSound?.fileName {
                 WidgetManager.addMainSoundToWidget(baseImageName: baseImageName, melodyImageName: melodyImageName, whiteNoiseImageName: whiteNoiseImageName, name: mixedSound.name, id: mixedSound.id, isPlaying: isPlaying, isRecentPlay: false)
             }
         }

--- a/RelaxOn/Views/Home/Music/VolumeControlView.swift
+++ b/RelaxOn/Views/Home/Music/VolumeControlView.swift
@@ -57,9 +57,6 @@ struct VolumeControlView: View {
         userRepositories.remove(at: index ?? -1)
         userRepositories.insert(newMixedSound, at: index ?? -1)
         
-        userRepositoriesState.remove(at: index ?? -1)
-        userRepositoriesState.insert(newMixedSound, at: index ?? -1)
-        
         let data = getEncodedData(data: userRepositories)
         UserDefaultsManager.shared.recipes = data
     }

--- a/RelaxOn/Views/Home/Music/VolumeControlView.swift
+++ b/RelaxOn/Views/Home/Music/VolumeControlView.swift
@@ -57,6 +57,9 @@ struct VolumeControlView: View {
         userRepositories.remove(at: index ?? -1)
         userRepositories.insert(newMixedSound, at: index ?? -1)
         
+//        userRepositoriesState.remove(at: index ?? -1)
+//        userRepositoriesState.insert(newMixedSound, at: index ?? -1)
+        
         let data = getEncodedData(data: userRepositories)
         UserDefaultsManager.shared.recipes = data
     }

--- a/RelaxOn/Views/Onboarding/OnboardingView.swift
+++ b/RelaxOn/Views/Onboarding/OnboardingView.swift
@@ -143,15 +143,15 @@ extension OnboardingView {
                 .frame(height: 25)
                 .onChange(of: volumes[0]) { volume in
                     selectedBaseSound.audioVolume = volume
-                    baseAudioManager.changeVolume(track: selectedBaseSound.imageName, volume: volume)
+                    baseAudioManager.changeVolume(track: selectedBaseSound.fileName, volume: volume)
                 }
                 .onChange(of: volumes[1]) { volume in
                     selectedMelodySound.audioVolume = volume
-                    melodyAudioManager.changeVolume(track: selectedMelodySound.imageName, volume: volume)
+                    melodyAudioManager.changeVolume(track: selectedMelodySound.fileName, volume: volume)
                 }
                 .onChange(of: volumes[2]) { volume in
                     selectedWhiteNoiseSound.audioVolume = volume
-                    whiteNoiseAudioManager.changeVolume(track: selectedWhiteNoiseSound.imageName, volume: volume)
+                    whiteNoiseAudioManager.changeVolume(track: selectedWhiteNoiseSound.fileName, volume: volume)
                 }
                 
                 Text("\(Int(volumes[select] * 100))")


### PR DESCRIPTION
## 작업 내용 (Content)
- 이번에도, Release 브랜치에서 에러가 발생해서, 에러를 급히 수정했습니다.
- NewMusicView에서 볼륨을 변경시에 화면이 팅기는 오류를 일단은 수정했으나, 값이 바로 반영되지 않습니다.

## 기타 사항 (Etc)
VolumeControllView에서
```
userRepositoriesState.remove(at: index ?? -1)
```
이 코드에서 에러가 발생합니다.


NewMusicView가 닫힐 때,
```
userRepositoriesState = userRepositories
```
로 값을 새로 주어도, 프린트 해보니, 변경된 볼륨값이 저장이 되지 않습니다.

현재 브랜치에서는, UserDefault에는 '볼륨이 변경된 값'이 저장되기 때문에
NewMusicView에서 앱을 재실행하면 그 볼륨값을 확인할 수 있지만,
새로고침되지 않아서, 뷰에서 변경한 볼륨값이 바로 반영되지 않습니다.

## Close Issues

Close #208

## 관련 사진(Optional)
