### PR TITLE
[Bugfix] Volume Control시 NewMusicView가 꺼지는 현상 수정

### DIFF
--- a/RelaxOn/Model/MixedSound.swift
+++ b/RelaxOn/Model/MixedSound.swift
@@ -16,8 +16,8 @@ struct MixedSound: Identifiable, Codable, Equatable {
     let fileName: String
     let url: URL?
     
-    init(name: String, baseSound: Sound?, melodySound: Sound?, whiteNoiseSound: Sound?, fileName: String) {
-        self.id = MixedSound.getUniqueId()
+    init(id: Int = MixedSound.getUniqueId(), name: String, baseSound: Sound?, melodySound: Sound?, whiteNoiseSound: Sound?, fileName: String) {
+        self.id = id
         self.name = name
         self.baseSound = baseSound
         self.melodySound = melodySound

--- a/RelaxOn/Views/Home/Music/VolumeControlView.swift
+++ b/RelaxOn/Views/Home/Music/VolumeControlView.swift
@@ -39,12 +39,13 @@ struct VolumeControlView: View {
                                    fileName: localMelodySound.fileName)
         
         let newWhiteNoiseSound = Sound(id: localWhiteNoiseSound.id,
-                                    name: localWhiteNoiseSound.name,
-                                    soundType: localWhiteNoiseSound.soundType,
-                                    audioVolume: audioVolumes.whiteNoiseVolume,
-                                    fileName: localWhiteNoiseSound.fileName)
+                                       name: localWhiteNoiseSound.name,
+                                       soundType: localWhiteNoiseSound.soundType,
+                                       audioVolume: audioVolumes.whiteNoiseVolume,
+                                       fileName: localWhiteNoiseSound.fileName)
         
-        let newMixedSound = MixedSound(name: selectedMixedSound.name,
+        let newMixedSound = MixedSound(id: selectedMixedSound.id,
+                                       name: selectedMixedSound.name,
                                        baseSound: newBaseSound,
                                        melodySound: newMelodySound,
                                        whiteNoiseSound: newWhiteNoiseSound,
@@ -57,8 +58,8 @@ struct VolumeControlView: View {
         userRepositories.remove(at: index ?? -1)
         userRepositories.insert(newMixedSound, at: index ?? -1)
         
-//        userRepositoriesState.remove(at: index ?? -1)
-//        userRepositoriesState.insert(newMixedSound, at: index ?? -1)
+        userRepositoriesState.remove(at: index ?? -1)
+        userRepositoriesState.insert(newMixedSound, at: index ?? -1)
         
         let data = getEncodedData(data: userRepositories)
         UserDefaultsManager.shared.recipes = data
@@ -147,15 +148,15 @@ extension VolumeControlView {
                                 saveNewVolume()
                             }
                         }
-                            .background(.black)
-                            .cornerRadius(4)
-                            .accentColor(.white)
-                            .padding(.horizontal, 20)
-                            .onChange(of: audioVolumes.baseVolume) { newValue in
-                                print(newValue)
-                                viewModel.baseAudioManager.changeVolume(track: item.name,
-                                                              volume: newValue)
-                            }
+                        .background(.black)
+                        .cornerRadius(4)
+                        .accentColor(.white)
+                        .padding(.horizontal, 20)
+                        .onChange(of: audioVolumes.baseVolume) { newValue in
+                            print(newValue)
+                            viewModel.baseAudioManager.changeVolume(track: item.name,
+                                                                    volume: newValue)
+                        }
                         Text(String(Int(audioVolumes.baseVolume * 100)))
                             .foregroundColor(.systemGrey1)
                     case .melody:
@@ -164,15 +165,15 @@ extension VolumeControlView {
                                 saveNewVolume()
                             }
                         }
-                            .background(.black)
-                            .cornerRadius(4)
-                            .accentColor(.white)
-                            .padding(.horizontal, 20)
-                            .onChange(of: audioVolumes.melodyVolume) { newValue in
-                                print(newValue)
-                                viewModel.melodyAudioManager.changeVolume(track: item.name,
-                                                                volume: newValue)
-                            }
+                        .background(.black)
+                        .cornerRadius(4)
+                        .accentColor(.white)
+                        .padding(.horizontal, 20)
+                        .onChange(of: audioVolumes.melodyVolume) { newValue in
+                            print(newValue)
+                            viewModel.melodyAudioManager.changeVolume(track: item.name,
+                                                                      volume: newValue)
+                        }
                         Text(String(Int(audioVolumes.melodyVolume * 100)))
                             .foregroundColor(.systemGrey1)
                     case .whiteNoise:
@@ -181,15 +182,15 @@ extension VolumeControlView {
                                 saveNewVolume()
                             }
                         }
-                            .background(.black)
-                            .cornerRadius(4)
-                            .accentColor(.white)
-                            .padding(.horizontal, 20)
-                            .onChange(of: audioVolumes.whiteNoiseVolume) { newValue in
-                                print(newValue)
-                                viewModel.whiteNoiseAudioManager.changeVolume(track: item.name,
-                                                                 volume: newValue)
-                            }
+                        .background(.black)
+                        .cornerRadius(4)
+                        .accentColor(.white)
+                        .padding(.horizontal, 20)
+                        .onChange(of: audioVolumes.whiteNoiseVolume) { newValue in
+                            print(newValue)
+                            viewModel.whiteNoiseAudioManager.changeVolume(track: item.name,
+                                                                          volume: newValue)
+                        }
                         Text(String(Int(audioVolumes.whiteNoiseVolume * 100)))
                             .foregroundColor(.systemGrey1)
                     }


### PR DESCRIPTION
## 작업 내용 (Content)
- coby가 올려주신 내용을 보고 commit을 되돌아보니 getUniqueID() func가 생기면서 MixedSound 의 init에 id가 사라졌는데 이 때문에 생기는 버그인 것 같습니다
<img width="1131" alt="스크린샷 2022-08-31 오후 2 41 46" src="https://user-images.githubusercontent.com/91456952/187603590-c5f4eadf-5013-4857-a98d-6a01cc9a115c.png">
- 볼륨 조절후 볼륨 잘 저장됩니다.

## 기타 사항 (Etc)
- 별개로 remove 되었다가 insert 되는 방식은 리팩토링되어야 할 것 같습니다. id를 넣어주면 NewMusicView가 왜 안 닫히는지는 의문입니다.🧐

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #211 

## 관련 사진(Optional)
