### PR TITLE
[fix] base 음원이 재생되지 않던 현상 & melody or whiteNoise, base에서 '선택 안함'을 선택한 것이 아니라 아무것도 누르지 않았을 때 생기는 버그

### DIFF
--- a/RelaxOn/Views/Home/Music/MusicViewModel.swift
+++ b/RelaxOn/Views/Home/Music/MusicViewModel.swift
@@ -87,9 +87,9 @@ final class MusicViewModel: NSObject, ObservableObject {
             whiteNoiseAudioManager.playPause()
         } else {
             // play 할 때 mixedSound 볼륨 적용 시도
-            baseAudioManager.startPlayer(track: mixedSound?.baseSound?.name ?? "base_default", volume: mixedSound?.baseSound?.audioVolume ?? 0.8)
-            melodyAudioManager.startPlayer(track: mixedSound?.melodySound?.name ?? "base_default", volume: mixedSound?.melodySound?.audioVolume ?? 0.8)
-            whiteNoiseAudioManager.startPlayer(track: mixedSound?.whiteNoiseSound?.name ?? "base_default", volume: mixedSound?.whiteNoiseSound?.audioVolume ?? 0.8)
+            baseAudioManager.startPlayer(track: mixedSound?.baseSound?.fileName ?? "base_default", volume: mixedSound?.baseSound?.audioVolume ?? 0.8)
+            melodyAudioManager.startPlayer(track: mixedSound?.melodySound?.fileName ?? "base_default", volume: mixedSound?.melodySound?.audioVolume ?? 0.8)
+            whiteNoiseAudioManager.startPlayer(track: mixedSound?.whiteNoiseSound?.fileName ?? "base_default", volume: mixedSound?.whiteNoiseSound?.audioVolume ?? 0.8)
         }
         updateCompanion()
 
@@ -103,9 +103,9 @@ final class MusicViewModel: NSObject, ObservableObject {
     }
     
     func startPlayer() {
-        baseAudioManager.startPlayer(track: mixedSound?.baseSound?.name ?? "base_default", volume: mixedSound?.baseSound?.audioVolume ?? 0.8)
-        melodyAudioManager.startPlayer(track: mixedSound?.melodySound?.name ?? "base_default", volume: mixedSound?.melodySound?.audioVolume ?? 0.8)
-        whiteNoiseAudioManager.startPlayer(track: mixedSound?.whiteNoiseSound?.name ?? "base_default", volume: mixedSound?.whiteNoiseSound?.audioVolume ?? 0.8)
+        baseAudioManager.startPlayer(track: mixedSound?.baseSound?.fileName ?? "base_default", volume: mixedSound?.baseSound?.audioVolume ?? 0.8)
+        melodyAudioManager.startPlayer(track: mixedSound?.melodySound?.fileName ?? "base_default", volume: mixedSound?.melodySound?.audioVolume ?? 0.8)
+        whiteNoiseAudioManager.startPlayer(track: mixedSound?.whiteNoiseSound?.fileName ?? "base_default", volume: mixedSound?.whiteNoiseSound?.audioVolume ?? 0.8)
     }
     
     func setupRemoteCommandCenter() {

--- a/RelaxOn/Views/Home/Music/MusicViewModel.swift
+++ b/RelaxOn/Views/Home/Music/MusicViewModel.swift
@@ -12,18 +12,18 @@ import WatchConnectivity
 
 final class MusicViewModel: NSObject, ObservableObject {
     @Published var watchInfo: [String] = []
-        
+    
     override init() {
         super.init()
-
+        
         guard WCSession.isSupported() else {
             return
         }
-
+        
         WCSession.default.delegate = self
         WCSession.default.activate()
     }
-
+    
     public func send(cdInfos: [String]) {
         guard WCSession.default.activationState == .activated else {
             return
@@ -80,19 +80,11 @@ final class MusicViewModel: NSObject, ObservableObject {
     }
     
     func playPause() {
+        baseAudioManager.playPause()
+        melodyAudioManager.playPause()
+        whiteNoiseAudioManager.playPause()
         self.isPlaying.toggle()
-        if !isPlaying {
-            baseAudioManager.playPause()
-            melodyAudioManager.playPause()
-            whiteNoiseAudioManager.playPause()
-        } else {
-            // play 할 때 mixedSound 볼륨 적용 시도
-            baseAudioManager.startPlayer(track: mixedSound?.baseSound?.fileName ?? "base_default", volume: mixedSound?.baseSound?.audioVolume ?? 0.8)
-            melodyAudioManager.startPlayer(track: mixedSound?.melodySound?.fileName ?? "base_default", volume: mixedSound?.melodySound?.audioVolume ?? 0.8)
-            whiteNoiseAudioManager.startPlayer(track: mixedSound?.whiteNoiseSound?.fileName ?? "base_default", volume: mixedSound?.whiteNoiseSound?.audioVolume ?? 0.8)
-        }
         updateCompanion()
-
     }
     
     func stop() {
@@ -148,7 +140,7 @@ final class MusicViewModel: NSObject, ObservableObject {
             })
         }
         // MARK: - 타이머 연동돌 때 건드릴 코드
-//        nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = self.baseAudioManager.player?.duration
+        //        nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = self.baseAudioManager.player?.duration
         nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = 1
         nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = NSNumber(value: self.baseAudioManager.player?.currentTime ?? 0.0)
         
@@ -222,7 +214,7 @@ extension MusicViewModel: WCSessionDelegate {
     private func session(_ session: WCSession, didReceiveMessage message: [String : Any], replyHander: @escaping ([String:Any]) -> Void) {
         print("received message from watch")
         let key = "watchInfo"
-            guard let WatchInfo = message[key] as? [String] else {
+        guard let WatchInfo = message[key] as? [String] else {
             return
         }
         
@@ -252,13 +244,13 @@ extension MusicViewModel: WCSessionDelegate {
             print("unknown watchinfo")
         }
     }
-
+    
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any] = [:]) {
         print("received from watch")
         
         DispatchQueue.main.async {
             let key = "watchInfo"
-                guard let WatchInfo = userInfo[key] as? [String] else {
+            guard let WatchInfo = userInfo[key] as? [String] else {
                 return
             }
             
@@ -289,14 +281,14 @@ extension MusicViewModel: WCSessionDelegate {
             }
         }
     }
-
+    
     // iOS에만 해당
-    #if os(iOS)
+#if os(iOS)
     func sessionDidBecomeInactive(_ session: WCSession) {
     }
     func sessionDidDeactivate(_ session: WCSession) {
         // 애플워치가 2개 이상일 때, 새로운 기기에서 다시 activate
         WCSession.default.activate()
     }
-    #endif
+#endif
 }

--- a/RelaxOn/Views/Home/Music/MusicViewModel.swift
+++ b/RelaxOn/Views/Home/Music/MusicViewModel.swift
@@ -153,6 +153,7 @@ final class MusicViewModel: NSObject, ObservableObject {
         let index = userRepositories.firstIndex { element in
             element.name == mixedSound.name
         }
+        self.playPause()
         self.isPlaying = true
         if index == count - 1 {
             guard let firstSong = userRepositories.first else { return }
@@ -176,6 +177,7 @@ final class MusicViewModel: NSObject, ObservableObject {
         let index = userRepositories.firstIndex { element in
             element.name == mixedSound.name
         }
+        self.playPause()
         self.isPlaying = true
         if index == 0 {
             guard let lastSong = userRepositories.last else { return }

--- a/RelaxOn/Views/Home/Music/NewMusicView.swift
+++ b/RelaxOn/Views/Home/Music/NewMusicView.swift
@@ -229,7 +229,6 @@ extension NewMusicView {
                         .frame(width: .infinity, height: .infinity)
             }
             if let whiteNoiseSoundImageName = viewModel.mixedSound?.whiteNoiseSound?.fileName {
-                let _ = print(whiteNoiseSoundImageName, "왜")
                     Image(whiteNoiseSoundImageName)
                         .resizable()
                         .opacity(whiteNoiseSoundImageName == "music" ? 0.0 : 0.5)

--- a/RelaxOn/Views/Home/Music/VolumeControlView.swift
+++ b/RelaxOn/Views/Home/Music/VolumeControlView.swift
@@ -32,6 +32,7 @@ struct VolumeControlView: View {
                                  soundType: localBaseSound.soundType,
                                  audioVolume: audioVolumes.baseVolume,
                                  fileName: localBaseSound.fileName)
+        
         let newMelodySound = Sound(id: localMelodySound.id,
                                    name: localMelodySound.name,
                                    soundType: localMelodySound.soundType,
@@ -154,7 +155,7 @@ extension VolumeControlView {
                         .padding(.horizontal, 20)
                         .onChange(of: audioVolumes.baseVolume) { newValue in
                             print(newValue)
-                            viewModel.baseAudioManager.changeVolume(track: item.name,
+                            viewModel.baseAudioManager.changeVolume(track: item.fileName,
                                                                     volume: newValue)
                         }
                         Text(String(Int(audioVolumes.baseVolume * 100)))
@@ -171,7 +172,7 @@ extension VolumeControlView {
                         .padding(.horizontal, 20)
                         .onChange(of: audioVolumes.melodyVolume) { newValue in
                             print(newValue)
-                            viewModel.melodyAudioManager.changeVolume(track: item.name,
+                            viewModel.melodyAudioManager.changeVolume(track: item.fileName,
                                                                       volume: newValue)
                         }
                         Text(String(Int(audioVolumes.melodyVolume * 100)))
@@ -188,7 +189,7 @@ extension VolumeControlView {
                         .padding(.horizontal, 20)
                         .onChange(of: audioVolumes.whiteNoiseVolume) { newValue in
                             print(newValue)
-                            viewModel.whiteNoiseAudioManager.changeVolume(track: item.name,
+                            viewModel.whiteNoiseAudioManager.changeVolume(track: item.fileName,
                                                                           volume: newValue)
                         }
                         Text(String(Int(audioVolumes.whiteNoiseVolume * 100)))

--- a/RelaxOn/Views/Kitchen/StudioView.swift
+++ b/RelaxOn/Views/Kitchen/StudioView.swift
@@ -12,20 +12,20 @@ struct StudioView: View {
     @State var select: Int = 0
     @State var showingConfirm = false
     @State var selectedBaseSound: Sound = Sound(id: 0,
-                                                name: "",
+                                                name: "Empty",
                                                 soundType: .base,
                                                 audioVolume: 0.5,
-                                                fileName: "")
+                                                fileName: "music")
     @State var selectedMelodySound: Sound = Sound(id: 10,
-                                                  name: "",
+                                                  name: "Empty",
                                                   soundType: .melody,
                                                   audioVolume: 0.5,
-                                                  fileName: "")
+                                                  fileName: "music")
     @State var selectedWhiteNoiseSound: Sound = Sound(id: 20,
-                                                      name: "",
+                                                      name: "Empty",
                                                       soundType: .whiteNoise,
                                                       audioVolume: 0.5,
-                                                      fileName: "")
+                                                      fileName: "music")
     @State var selectedImageNames: (base: String, melody: String, whiteNoise: String) = (
         base: "",
         melody: "",
@@ -135,6 +135,7 @@ extension StudioView {
                                 
                                 opacityAnimationValues[0] = 0.0
                             } else {
+                                print(baseSelected.name, "하하이")
                                 baseAudioManager.startPlayer(track: selectedBaseSound.fileName, volume: volumes[select])
                                 
                                 selectedImageNames.base = "BaseIllust"

--- a/RelaxOn/Views/Onboarding/OnboardingView.swift
+++ b/RelaxOn/Views/Onboarding/OnboardingView.swift
@@ -11,20 +11,20 @@ struct OnboardingView: View {
     // MARK: - State Properties
     @State var select: Int = 0
     @State var selectedBaseSound: Sound = Sound(id: 0,
-                                                name: "",
+                                                name: "Empty",
                                                 soundType: .base,
                                                 audioVolume: 0.5,
-                                                fileName: "")
+                                                fileName: "music")
     @State var selectedMelodySound: Sound = Sound(id: 10,
-                                                  name: "",
+                                                  name: "Empty",
                                                   soundType: .melody,
                                                   audioVolume: 0.5,
-                                                  fileName: "")
+                                                  fileName: "music")
     @State var selectedWhiteNoiseSound: Sound = Sound(id: 20,
-                                                      name: "",
+                                                      name: "Empty",
                                                       soundType: .whiteNoise,
                                                       audioVolume: 0.5,
-                                                      fileName: "")
+                                                      fileName: "music")
 
     @State var selectedImageNames: (base: String, melody: String, whiteNoise: String) = (
         base: "",


### PR DESCRIPTION
## 작업 내용 (Content)
- base 음원이 재생되지 않은 현상 해결 -> 음원을 재생하는 startPlayer에서 .name을 사용하고 있었기 때문에 base음원이 재생되지 않고 있었음 
-> name을 fileName으로 수정하여 해결
- melody or whiteNoise, base에서 '선택 안함'을 선택한 것이 아니라 아무것도 누르지 않은 상태로 믹스할 때 Umbrella Rain이 재생되는 현상이 있었음 
-> 아무것도 누르지 않았을 때에도 '선택 안함'을 누른 것처럼 음원을 저장하여 해결
- 어떤 MixedSound의 어떤 SoundType이 empty일 때 옆에 있는 곡의 해당 SoundType이 Empty가 아닐경우 >> or <<를 눌렀을 때 Empty가 아닌 곡이 계속 재생되는 현상 
-> >> or << 클릭시 동작되는 함수에 playPause()를 추가하여 해결
- startPlayer() 리팩토링

## 기타 사항 (Etc)
- studio에서 아무것도 누르지 않고 넘어갔을 때 Umbrella Rain이 왜 재생되었는지 알 수 없었음.. 해결방법은 살짝 야매느낌.. Empty를 선택했을 때에는 Umbrella Rain이 재생되지 않았음
- '>>' 와 << 버튼의 동작이 느려진 것 같은 느낌(?)

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #226 

## 관련 사진(Optional)
