### PR TITLE
[Fix] StudioView에서 선택한 이미지가 보여지지 않고 하나의 이미지만 보여주던 현상 & 이미지 겹치는 부분에 opacity제거

### DIFF
--- a/RelaxOn/Views/Home/CDCardView.swift
+++ b/RelaxOn/Views/Home/CDCardView.swift
@@ -19,32 +19,46 @@ struct CDCardView: View {
                 self.selectedMixedSound = data
                 self.isShwoingMusicView.toggle()
             }, label: {
-                    ZStack {
-                        if let baseSoundImageName = data.baseSound?.fileName {
+                ZStack {
+                    if let baseSoundImageName = data.baseSound?.fileName {
+                        switch baseSoundImageName {
+                        case "music":
+                            EmptyView()
+                        default:
                             Image(baseSoundImageName)
                                 .resizable()
-                                .opacity(baseSoundImageName == "music" ? 0 : 0.5)
                                 .frame(width: UIScreen.main.bounds.width * 0.43, height: UIScreen.main.bounds.width * 0.43)
                         }
-                        if let melodySoundImageName = data.melodySound?.fileName {
+                    }
+                    
+                    if let melodySoundImageName = data.melodySound?.fileName {
+                        switch melodySoundImageName {
+                        case "music":
+                            EmptyView()
+                        default:
                             Image(melodySoundImageName)
                                 .resizable()
-                                .opacity(melodySoundImageName == "music" ? 0 : 0.5)
                                 .frame(width: UIScreen.main.bounds.width * 0.43, height: UIScreen.main.bounds.width * 0.43)
                         }
-                        if let whiteNoiseSoundImageName = data.whiteNoiseSound?.fileName {
+                    }
+                    
+                    if let whiteNoiseSoundImageName = data.whiteNoiseSound?.fileName {
+                        switch whiteNoiseSoundImageName {
+                        case "music":
+                            EmptyView()
+                        default:
                             Image(whiteNoiseSoundImageName)
                                 .resizable()
-                                .opacity(whiteNoiseSoundImageName == "music" ? 0 : 0.5)
                                 .frame(width: UIScreen.main.bounds.width * 0.43, height: UIScreen.main.bounds.width * 0.43)
                         }
                     }
-                    .fullScreenCover(item: $selectedMixedSound) { _ in
-                        NewMusicView(data: data, userRepositoriesState: $userRepositoriesState)
-                    }
-                    .fullScreenCover(isPresented: $isPresent, content: {
-                        NewMusicView(data: data, userRepositoriesState: $userRepositoriesState)
-                    })
+                }
+                .fullScreenCover(item: $selectedMixedSound) { _ in
+                    NewMusicView(data: data, userRepositoriesState: $userRepositoriesState)
+                }
+                .fullScreenCover(isPresented: $isPresent) {
+                    NewMusicView(data: data, userRepositoriesState: $userRepositoriesState)
+                }
             })
             Text(data.name)
                 .font(.system(size: 17, weight: .regular))

--- a/RelaxOn/Views/Home/Music/NewMusicView.swift
+++ b/RelaxOn/Views/Home/Music/NewMusicView.swift
@@ -217,23 +217,34 @@ extension NewMusicView {
     func CDCoverView() -> some View {
         ZStack {
             if let baseSoundImageName = viewModel.mixedSound?.baseSound?.fileName {
+                switch baseSoundImageName {
+                case "music":
+                    EmptyView()
+                default:
                     Image(baseSoundImageName)
                         .resizable()
-                        .opacity(baseSoundImageName == "music" ? 0.0 : 0.5)
                         .frame(width: .infinity, height: .infinity)
+                }
             }
             if let melodySoundImageName = viewModel.mixedSound?.melodySound?.fileName {
+                switch melodySoundImageName {
+                case "music":
+                    EmptyView()
+                default:
                     Image(melodySoundImageName)
                         .resizable()
-                        .opacity(melodySoundImageName == "music" ? 0.0 : 0.5)
                         .frame(width: .infinity, height: .infinity)
+                }
             }
             if let whiteNoiseSoundImageName = viewModel.mixedSound?.whiteNoiseSound?.fileName {
-                let _ = print(whiteNoiseSoundImageName, "왜")
+                switch whiteNoiseSoundImageName {
+                case "music":
+                    EmptyView()
+                default:
                     Image(whiteNoiseSoundImageName)
                         .resizable()
-                        .opacity(whiteNoiseSoundImageName == "music" ? 0.0 : 0.5)
                         .frame(width: .infinity, height: .infinity)
+                }
             }
 //            Image(viewModel.mixedSound?.melodySound?.imageName ?? "")
 //                .resizable()

--- a/RelaxOn/Views/Kitchen/SelectedImageView.swift
+++ b/RelaxOn/Views/Kitchen/SelectedImageView.swift
@@ -34,7 +34,6 @@ extension SelectedImageView {
             
             // Melody
             IllustImage(imageName: selectedImageNames.melody, animateVar: opacityAnimationValues[1])
-                .blendMode(.darken)
             
             // WhiteNoise
             IllustImage(imageName: selectedImageNames.whiteNoise, animateVar: opacityAnimationValues[2])

--- a/RelaxOn/Views/Kitchen/StudioView.swift
+++ b/RelaxOn/Views/Kitchen/StudioView.swift
@@ -137,7 +137,7 @@ extension StudioView {
                             } else {
                                 baseAudioManager.startPlayer(track: selectedBaseSound.fileName, volume: volumes[select])
                                 
-                                selectedImageNames.base = "BaseIllust"
+                                selectedImageNames.base = selectedBaseSound.fileName
                                 opacityAnimationValues[0] = 1
                             }
                         }
@@ -153,7 +153,7 @@ extension StudioView {
                             } else {
                                 melodyAudioManager.startPlayer(track: selectedMelodySound.fileName, volume: volumes[select])
                                 
-                                selectedImageNames.melody = "MelodyIllust"
+                                selectedImageNames.melody = selectedMelodySound.fileName
                                 opacityAnimationValues[1] = 1
                             }
                         }
@@ -169,7 +169,7 @@ extension StudioView {
                             } else {
                                 whiteNoiseAudioManager.startPlayer(track: selectedWhiteNoiseSound.fileName, volume: volumes[select])
                                 
-                                selectedImageNames.whiteNoise = ""//selectedWhiteNoiseSound.imageName
+                                selectedImageNames.whiteNoise = selectedWhiteNoiseSound.fileName
                                 opacityAnimationValues[2] = 0.5
                             }
                         }

--- a/RelaxOn/Views/Kitchen/StudioView.swift
+++ b/RelaxOn/Views/Kitchen/StudioView.swift
@@ -138,7 +138,7 @@ extension StudioView {
                                 baseAudioManager.startPlayer(track: selectedBaseSound.fileName, volume: volumes[select])
                                 
                                 selectedImageNames.base = selectedBaseSound.fileName
-                                opacityAnimationValues[0] = 1
+                                opacityAnimationValues[0] = 1.0
                             }
                         }
                     case .melody:
@@ -154,7 +154,7 @@ extension StudioView {
                                 melodyAudioManager.startPlayer(track: selectedMelodySound.fileName, volume: volumes[select])
                                 
                                 selectedImageNames.melody = selectedMelodySound.fileName
-                                opacityAnimationValues[1] = 1
+                                opacityAnimationValues[1] = 1.0
                             }
                         }
                     case .whiteNoise:
@@ -170,7 +170,7 @@ extension StudioView {
                                 whiteNoiseAudioManager.startPlayer(track: selectedWhiteNoiseSound.fileName, volume: volumes[select])
                                 
                                 selectedImageNames.whiteNoise = selectedWhiteNoiseSound.fileName
-                                opacityAnimationValues[2] = 0.5
+                                opacityAnimationValues[2] = 1.0
                             }
                         }
                     }

--- a/RelaxOn/Views/Onboarding/OnboardingView.swift
+++ b/RelaxOn/Views/Onboarding/OnboardingView.swift
@@ -178,7 +178,7 @@ extension OnboardingView {
                                 baseAudioManager.startPlayer(track: selectedBaseSound.fileName)
 
                                 selectedImageNames.base = selectedBaseSound.fileName
-                                opacityAnimationValues[0] = 0.5
+                                opacityAnimationValues[0] = 1.0
                             }
                         }
 
@@ -197,7 +197,7 @@ extension OnboardingView {
 
                                 selectedImageNames.whiteNoise = selectedWhiteNoiseSound.fileName
 
-                                opacityAnimationValues[2] = 0.5
+                                opacityAnimationValues[2] = 1.0
                             }
                         }
                     case .melody:
@@ -214,7 +214,7 @@ extension OnboardingView {
 
                                 selectedImageNames.melody = selectedMelodySound.fileName
 
-                                opacityAnimationValues[1] = 0.5
+                                opacityAnimationValues[1] = 1.0
 
                             }
                         }


### PR DESCRIPTION
## 작업 내용 (Content)
- StudioView에서 선택한 이미지가 보여지지 않고 하나의 이미지만 보여주던 현상을 수정하였습니다.
- opacity가 없더라도 이미지가 잘 겹치기 때문에 이미지가 겹치는 뷰의 opacity를 제거하였습니다. StudioView에서는 opacity로 애니메이션을 주고 있어서 opacity를 제거하지않고 1.0으로 변경하였습니다.

## 기타 사항 (Etc)
- opacity를 제거하는 과정에서 EmptyView()를 사용하였는데, EmptyView()를 return하는 방법 말고, 아예 아무것도 return 하지 않는 방법이 있을까요?

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #228 

## 관련 사진(Optional)
