### PR TITLE
[Fix] StudioView BackButton 터치영역 수정

### DIFF
--- a/RelaxOn/Views/Kitchen/StudioView.swift
+++ b/RelaxOn/Views/Kitchen/StudioView.swift
@@ -208,8 +208,13 @@ extension StudioView {
             Button(action: {
                 showingConfirm = true
             }, label: {
-                Image(systemName: "chevron.backward")
-                    .foregroundColor(.relaxDimPurple)
+                HStack {
+                    Image(systemName: "chevron.backward")
+                        .foregroundColor(.relaxDimPurple)
+                    Text("CD LIBRARY")
+                        .font(.system(size: 15, weight: .regular))
+                        .foregroundColor(.relaxDimPurple)
+                }
             })
             .confirmationDialog("나가면 사라집니다...", isPresented: $showingConfirm, titleVisibility: .visible) {
                 Button("Leave Studio", role: .destructive){
@@ -217,9 +222,7 @@ extension StudioView {
                 }
                 Button("Cancel", role: .cancel){}
             }
-            Text("CD LIBRARY")
-                .font(.system(size: 15, weight: .regular))
-                .foregroundColor(.relaxDimPurple)
+            
             Spacer()
         }.padding()
     }


### PR DESCRIPTION
## 작업 내용 (Content)
- StudioView에서 chevron에만 터치영역이 지정되어 있던 것을 "CD LIBRARY"까지 확대하였습니다.

## 기타 사항 (Etc)
- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #221 

## 관련 사진(Optional)
