### PR TITLE
[fix] CDLibraryView에서 편집시 원크기 수정

### DIFF
--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -48,11 +48,15 @@ struct CDListView: View {
                                 if isEditMode {
                                     if selectedMixedSoundIds.firstIndex(where: {$0 == mixedSound.id}) != nil {
                                         Image(systemName: "checkmark.circle.fill")
+                                            .resizable()
+                                            .frame(width: 24.0, height: 24.0)
                                             .foregroundColor(.white)
                                             .padding(.bottom, LayoutConstants.Padding.bottomOfRadioButton)
                                             .padding(.trailing, LayoutConstants.Padding.trailingOfRadioButton)
                                     } else {
                                         Image(systemName: "circle")
+                                            .resizable()
+                                            .frame(width: 24.0, height: 24.0)
                                             .foregroundColor(.white)
                                             .background(Image(systemName: "circle.fill").foregroundColor(.gray).opacity(0.5))
                                             .padding(.bottom, LayoutConstants.Padding.bottomOfRadioButton)


### PR DESCRIPTION
## 작업 내용 (Content)
- CDLibraryView에서 편집시 원크기를 수정하였습니다.
- 기존에는 크기 값이 없어서, 피그마 값인 24로 변경하였습니다.

## 기타 사항 (Etc)

## Close Issues

Close #220

## 관련 사진(Optional)
![Simulator Screen Shot - iPhone 13 - 2022-09-01 at 20 41 09](https://user-images.githubusercontent.com/57849386/187905813-72ae41c7-44ba-4b34-b436-97538b91763d.png)
