### PR TITLE
[fix] CD를 클릭했을 때도 위젯에 재생된 CD data가 저장되도록 

### DIFF
--- a/RelaxOn/Views/Home/Music/NewMusicView.swift
+++ b/RelaxOn/Views/Home/Music/NewMusicView.swift
@@ -146,6 +146,12 @@ struct NewMusicView: View {
                 }
                 self.isFetchFirstData = false
                 timerManager.currentMusicViewModel = self.viewModel
+                if let mixedSound = viewModel.mixedSound,
+                   let baseImageName = viewModel.mixedSound?.baseSound?.fileName,
+                   let melodyImageName = viewModel.mixedSound?.melodySound?.fileName,
+                   let whiteNoiseImageName = viewModel.mixedSound?.whiteNoiseSound?.fileName {
+                    WidgetManager.addMainSoundToWidget(baseImageName: baseImageName, melodyImageName: melodyImageName, whiteNoiseImageName: whiteNoiseImageName, name: mixedSound.name, id: mixedSound.id, isPlaying: viewModel.isPlaying, isRecentPlay: false)
+                }
             }
             .onReceive(viewModel.$mixedSound, perform: { mixedSound in
                 guard let changedMixedSound = mixedSound else { return }


### PR DESCRIPTION
## 작업 내용 (Content)
- 리뷰어가 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 간략하게 작성합니다.
이전에는 CD를 눌러도 위젯에 최근 재생 CD가 반영되지 않았고, 
play or pause 버튼을 눌러야지만 반영이 되었습니다.

## 기타 사항 (Etc)
- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등
MusicViewModel play() 함수에 widget에 데이터가 들어가는 부분을 넣어뒀는데  CD를 눌렀을 때는 반영이 안 되는 것을 보아
로직을 조금 고치면 어떨까 제안합니다...(지금은 임시로 같은 함수를 호출해놨습니다 ) MusicViewModel 과 NewMusicView 코드 짜신 분께 자세한 의논을 하고 싶습니다 슬랙으로 연락주세요 ~ !

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #235

## 관련 사진(Optional)
