### PR TITLE
[fix] 베이스, 멜로디, 백색소음 탭 좌우정렬

### DIFF
--- a/RelaxOn/Utilities/Static.swift
+++ b/RelaxOn/Utilities/Static.swift
@@ -104,7 +104,7 @@ final class deviceFrame {
     static let screenWidth = UIScreen.main.bounds.size.width
     static let screenHeight = UIScreen.main.bounds.size.height
     static var exceptPaddingWidth: CGFloat {
-        return screenWidth - 30
+        return screenWidth - 40
     }
 }
 

--- a/RelaxOn/Views/Kitchen/CustomSegmentControlView.swift
+++ b/RelaxOn/Views/Kitchen/CustomSegmentControlView.swift
@@ -12,7 +12,7 @@ public struct CustomSegmentControlView: View {
     @State private var segmentSize: CGSize = .zero
     @State private var itemTitleSizes: [CGSize] = []
     @Binding private var selection: Int
-    
+
     // MARK: - General Properties
     private let items: [LocalizedStringKey]
     
@@ -21,9 +21,8 @@ public struct CustomSegmentControlView: View {
     }
     
     private var xSpace: CGFloat {
-        guard !itemTitleSizes.isEmpty, !items.isEmpty, segmentSize.width != 0 else { return 0 }
         let itemWidthSum: CGFloat = itemTitleSizes.map { $0.width }.reduce(0, +).rounded()
-        let space = (segmentSize.width - itemWidthSum) / CGFloat(items.count + 1)
+        let space = (segmentSize.width - itemWidthSum) / CGFloat(items.count - 1)
         return max(space, 0)
     }
     
@@ -36,15 +35,15 @@ public struct CustomSegmentControlView: View {
         let isSelected = self.selection == index
 
         return
-            Text(items[index])
-                .font(.caption)
-                .foregroundColor(isSelected ? .white : .gray)
-                .background(BackgroundGeometryReader())
-                .onPreferenceChange(SizePreferenceKey.self) {
-                    itemTitleSizes[index] = $0
-                }
-                .onTapGesture { onItemTap(index: index) }
-                .eraseToAnyView()
+        Text(items[index])
+            .font(.body)
+            .foregroundColor(isSelected ? .white : .gray)
+            .background(BackgroundGeometryReader())
+            .onPreferenceChange(SizePreferenceKey.self) {
+                itemTitleSizes[index] = $0
+            }
+            .onTapGesture { onItemTap(index: index) }
+            .eraseToAnyView()
     }
 
     private func onItemTap(index: Int) {
@@ -53,15 +52,16 @@ public struct CustomSegmentControlView: View {
     }
 
     private func selectedItemHorizontalOffset() -> CGFloat {
-        guard selectedItemWidth != .zero, selection != 0 else { return 0 }
-
+        guard selectedItemWidth != .zero, selection != 0 else { return 20 }
+        // selected Item이전까지의 select된 title의 width값의 합
         let result = itemTitleSizes
             .enumerated()
             .filter { $0.offset < selection }
             .map { $0.element.width }
             .reduce(0, +)
 
-        return result + xSpace * CGFloat(selection)
+        return 20 + 36 * CGFloat(selection) + result
+//        return result + xSpace * CGFloat(selection)
     }
     
     // MARK: - Life Cycles
@@ -74,34 +74,29 @@ public struct CustomSegmentControlView: View {
 
     public var body: some View {
         ZStack {
-            GeometryReader { geometry in
-                Color
-                    .clear
-                    .onAppear {
-                        segmentSize = geometry.size
-                    }
-            }
-            .frame(maxWidth: .infinity, maxHeight: 1)
 
-            VStack(alignment: .center, spacing: 0) {
+            HStack {
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(spacing: xSpace) {
                         ForEach(0 ..< items.count, id: \.self) { index in
                             segmentItemView(for: index)
+                                .padding(.leading, index == 0 ? 20 : 36)
                         }
                     }
-                    .padding(.bottom, 5)
+                    .padding(.bottom, 2)
 
                     // 선택된 요소 밑줄
                     Rectangle()
                         .foregroundColor(.white)
-                        .frame(width: selectedItemWidth, height: 3)
+                        .frame(width: selectedItemWidth, height: 2)
                         .offset(x: selectedItemHorizontalOffset(), y: 0)
                         .animation(Animation.linear(duration: 0.3), value: selectedItemWidth)
+
                 }
                 .padding(.horizontal, xSpace)
-
+                Spacer()
             }
+
         }
     }
 }

--- a/RelaxOn/Views/Kitchen/CustomSegmentControlView.swift
+++ b/RelaxOn/Views/Kitchen/CustomSegmentControlView.swift
@@ -20,11 +20,12 @@ public struct CustomSegmentControlView: View {
         return itemTitleSizes.count > selection ? itemTitleSizes[selection].width : .zero
     }
     
-    private var xSpace: CGFloat {
-        let itemWidthSum: CGFloat = itemTitleSizes.map { $0.width }.reduce(0, +).rounded()
-        let space = (segmentSize.width - itemWidthSum) / CGFloat(items.count - 1)
-        return max(space, 0)
-    }
+//    private var xSpace: CGFloat {
+//        let itemWidthSum: CGFloat = itemTitleSizes.map { $0.width }.reduce(0, +).rounded()
+//        let space = (segmentSize.width - itemWidthSum) / CGFloat(items.count - 1)
+//        return max(space, 0)
+//
+//    }
     
     // MARK: - Methods
     private func segmentItemView(for index: Int) -> some View {
@@ -77,7 +78,7 @@ public struct CustomSegmentControlView: View {
 
             HStack {
                 VStack(alignment: .leading, spacing: 0) {
-                    HStack(spacing: xSpace) {
+                    HStack(spacing: 0) {
                         ForEach(0 ..< items.count, id: \.self) { index in
                             segmentItemView(for: index)
                                 .padding(.leading, index == 0 ? 20 : 36)
@@ -93,7 +94,7 @@ public struct CustomSegmentControlView: View {
                         .animation(Animation.linear(duration: 0.3), value: selectedItemWidth)
 
                 }
-                .padding(.horizontal, xSpace)
+//                .padding(.horizontal, 36)
                 Spacer()
             }
 

--- a/RelaxOn/Views/Kitchen/RectPreference.swift
+++ b/RelaxOn/Views/Kitchen/RectPreference.swift
@@ -18,8 +18,6 @@ struct SizePreferenceKey: PreferenceKey {
 }
 
 struct BackgroundGeometryReader: View {
-    public init() {}
-
     public var body: some View {
         GeometryReader { geometry in
             return Color

--- a/RelaxOn/Views/Onboarding/OnboardingView.swift
+++ b/RelaxOn/Views/Onboarding/OnboardingView.swift
@@ -83,7 +83,9 @@ struct OnboardingView: View {
                     }.padding(.horizontal)
 
                     SelectedImageView(selectedImageNames: $selectedImageNames, opacityAnimationValues: $opacityAnimationValues)
+
                     CustomSegmentControlView(items: items, selection: $select)
+
 
                     switch select {
                     case 1:


### PR DESCRIPTION
## 작업 내용 (Content)
- CustomSegmentControl 코드를 수정했습니다.
- 현재 좌표이동값을 하드코딩한 느낌이 있는데, 같이 봐주시면 매우,,,감사드리겠습니다...

## 기타 사항 (Etc)
- 왼쪽 정렬에 맞추기 위해 Spacer를 사용해서 맞췄는데, 한국어일떄와 영어일때와 텍스트의 길이가 차이가 나서 다른 해결 방안이나 디자인적으로 얘기를 하면 좋을 것 같습니다.
- 한국어일떄 베이스에서 멜로디로 이동시 애니메이션이 적용되지 않는 버그도 보여 다음 스프린트때 추가 작업으로 생각됩니다.
- xSpace값이 참조를 여러번 하는 것 같아 값이 점점 작아지는 상황이 나와 현재는 해결하지 못하고 추후에 해결을 위해 주석으로 남겨뒀습니다. 다음 스프린트때 코드 수정이 필요해보입니다..!



## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #216 

## 관련 사진(Optional)
![Simulator Screen Recording - iPhone 13 - 2022-09-01 at 21 29 47](https://user-images.githubusercontent.com/81131715/187915587-96edf9b2-bb07-43c3-b9cd-317de4cbcdd6.gif)
![Simulator Screen Recording - iPhone 13 - 2022-09-01 at 21 31 06](https://user-images.githubusercontent.com/81131715/187915603-b7ed8169-1b5d-45ce-b09a-0822772bf874.gif)
