### PR TITLE
[fix] MusicNaming 관련 뷰들 UI수정

### DIFF
--- a/RelaxOn/Views/Home/Music/MusicRenameView.swift
+++ b/RelaxOn/Views/Home/Music/MusicRenameView.swift
@@ -133,7 +133,7 @@ struct RenamePlaceholderCustom: ViewModifier {
     public func body(content: Content) -> some View {
         ZStack(alignment: .leading) {
             if showPlaceHolder {
-                Text(placeHolder)
+                Text(LocalizedStringKey(placeHolder))
                     .foregroundColor(.systemGrey1)
                     .font(.system(size: 17, weight: .light))
             }

--- a/RelaxOn/Views/Home/Music/MusicRenameView.swift
+++ b/RelaxOn/Views/Home/Music/MusicRenameView.swift
@@ -22,18 +22,18 @@ struct MusicRenameView: View {
             VStack {
                 HStack {
                     NamingBackButton()
-                        .padding(.horizontal, 15)
+                        .padding(.horizontal)
                     Spacer()
                 }
                 
                 HStack {
                     Text("Please name this CD")
-                        .frame(width: deviceFrame.exceptPaddingWidth / 2)
                         .font(.system(size: 28, weight: .medium))
                         .foregroundColor(.white)
-                        .lineLimit(2)
                     Spacer()
-                }.padding()
+                }
+                .padding(.horizontal)
+                .padding(.top, deviceFrame.screenHeight * 0.04)
                 
                 VStack {
                     TextField("", text: $textEntered)
@@ -41,7 +41,7 @@ struct MusicRenameView: View {
                         .modifier(RenamePlaceholderCustom(showPlaceHolder: textEntered.isEmpty, placeHolder: "Make your own CD"))
                         .keyboardType(.alphabet)
                         .multilineTextAlignment(.leading)
-                        .padding(.horizontal, 15)
+                        .padding(.horizontal)
                     
                     Rectangle()
                         .foregroundColor(.white)

--- a/RelaxOn/Views/Kitchen/StudioNamingView.swift
+++ b/RelaxOn/Views/Kitchen/StudioNamingView.swift
@@ -26,25 +26,25 @@ struct StudioNamingView: View {
             VStack {
                 HStack {
                     NamingBackButton()
-                        .padding(.horizontal, 15)
+                        .padding(.horizontal)
                     Spacer()
                 }
 
                 HStack {
                     Text("Please name this CD")
-                        .frame(width: deviceFrame.exceptPaddingWidth / 2)
                         .font(.system(size: 28, weight: .medium))
                         .foregroundColor(.white)
-                        .lineLimit(2)
                     Spacer()
-                }.padding()
+                }
+                .padding(.horizontal)
+                .padding(.top, deviceFrame.screenHeight * 0.04)
 
                 VStack {
                     TextField("", text: $textEntered)
                         .foregroundColor(.white)
                         .modifier(PlaceholderCustom(showPlaceHolder: textEntered.isEmpty, placeHolder: "Make your own CD"))
                         .keyboardType(.alphabet)
-                        .padding(.horizontal, 15)
+                        .padding(.horizontal)
 
                     Rectangle()
                         .foregroundColor(.white)

--- a/RelaxOn/Views/Onboarding/OnboadingNamingView.swift
+++ b/RelaxOn/Views/Onboarding/OnboadingNamingView.swift
@@ -26,19 +26,18 @@ struct OnboadingNamingView: View {
             VStack {
                 HStack {
                     Text("Please name this CD")
-                        .frame(width: deviceFrame.exceptPaddingWidth / 2)
                         .font(.system(size: 28, weight: .medium))
                         .foregroundColor(.white)
-                        .lineLimit(2)
                     Spacer()
-                }.padding()
-                
+                }
+                .padding(.horizontal)
+                .padding(.top, deviceFrame.screenHeight * 0.04)
+
                 VStack {
                     TextField("", text: $textEntered)
                         .foregroundColor(.white)
                         .modifier(PlaceholderCustom(showPlaceHolder: textEntered.isEmpty, placeHolder: "Make your own CD"))
-                        .keyboardType(.alphabet)
-                        .padding(.horizontal, 15)
+                        .padding(.horizontal)
                     
                     Rectangle()
                         .foregroundColor(.white)


### PR DESCRIPTION
## 작업 내용 (Content)
- 음원들의 이름을 설정 및 재설정 하는 뷰들의 UI를 수정했습니다.
- 데이크가 작업하신 MusicRenameView에 Localization이 적용되어있지않아 적용했습니다.

## 기타 사항 (Etc)
- 같은 기능을 하는 파일구조는 이슈를 생성해놓고 다음 스프린트때 작업하도록 하겠습니다.

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #217 

## 관련 사진(Optional)
<p align="left">
  <img width="200" alt="스크린샷1" src="https://user-images.githubusercontent.com/81131715/187937889-a717ec5f-642f-40ef-a6a0-f885a35219f9.png">
  <img width="200" alt="스크린샷2" src="https://user-images.githubusercontent.com/81131715/187938659-8dd0d916-e9ec-449d-8025-a9dd999f49fa.png">
</p>


