### PR TITLE
[fix] CD제작중 메인화면으로 돌아갔을 때 음원이 멈추도록 수정

### DIFF
--- a/RelaxOn/Views/Kitchen/StudioView.swift
+++ b/RelaxOn/Views/Kitchen/StudioView.swift
@@ -207,6 +207,9 @@ extension StudioView {
         HStack{
             Button(action: {
                 showingConfirm = true
+//                baseAudioManager.stop()
+//                melodyAudioManager.stop()
+//                whiteNoiseAudioManager.stop()
             }, label: {
                 Image(systemName: "chevron.backward")
                     .foregroundColor(.relaxDimPurple)
@@ -214,6 +217,9 @@ extension StudioView {
             .confirmationDialog("나가면 사라집니다...", isPresented: $showingConfirm, titleVisibility: .visible) {
                 Button("Leave Studio", role: .destructive){
                     presentationMode.wrappedValue.dismiss()
+                    baseAudioManager.stop()
+                    melodyAudioManager.stop()
+                    whiteNoiseAudioManager.stop()
                 }
                 Button("Cancel", role: .cancel){}
             }


### PR DESCRIPTION
## 작업 내용 (Content)
- StudioView에서 음원 제작중 메인화면으로 돌아갔을 때 음원이 멈추도록 수정했습니다.

## 기타 사항 (Etc)
- 현재는 confirmationDialog 에서 최종적으로 메인화면으로 갔을 때 음원이 멈추게 해놨습니다.
- 추가적으로  StudioView에서 좌측상단의 backButton을 누른 후  confirmationDialog가 떳을때 음원이 멈추게 할지 여부를 정해야 할 것 같습니다.
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #223 

## 관련 사진(Optional)
