### PR TITLE
[fix] material에서 base만 누르고 다른 것들은 '선택 안함'도 누르지 않고 바로 만든 경우 생기는 버그

### DIFF
--- a/RelaxOn/Manager/AudioManager.swift
+++ b/RelaxOn/Manager/AudioManager.swift
@@ -22,6 +22,7 @@ final class AudioManager {
     func startPlayer(track: String, volume: Float? = 1.0) {
         guard let url = getPathUrl(forResource: track, musicExtension: .mp3),
               let volume = volume else {
+            self.player = nil
             print("resource not found \(track)")
             return
         }

--- a/RelaxOn/Views/Home/Music/MusicViewModel.swift
+++ b/RelaxOn/Views/Home/Music/MusicViewModel.swift
@@ -153,7 +153,7 @@ final class MusicViewModel: NSObject, ObservableObject {
         let index = userRepositories.firstIndex { element in
             element.name == mixedSound.name
         }
-        self.stop()
+//        self.stop()
         self.isPlaying = true
         if index == count - 1 {
             guard let firstSong = userRepositories.first else { return }
@@ -177,7 +177,7 @@ final class MusicViewModel: NSObject, ObservableObject {
         let index = userRepositories.firstIndex { element in
             element.name == mixedSound.name
         }
-        self.stop()
+//        self.stop()
         self.isPlaying = true
         if index == 0 {
             guard let lastSong = userRepositories.last else { return }

--- a/RelaxOn/Views/Home/Music/MusicViewModel.swift
+++ b/RelaxOn/Views/Home/Music/MusicViewModel.swift
@@ -153,8 +153,8 @@ final class MusicViewModel: NSObject, ObservableObject {
         let index = userRepositories.firstIndex { element in
             element.name == mixedSound.name
         }
-//        self.stop()
         self.isPlaying = true
+        
         if index == count - 1 {
             guard let firstSong = userRepositories.first else { return }
             self.mixedSound = firstSong
@@ -177,8 +177,8 @@ final class MusicViewModel: NSObject, ObservableObject {
         let index = userRepositories.firstIndex { element in
             element.name == mixedSound.name
         }
-//        self.stop()
         self.isPlaying = true
+        
         if index == 0 {
             guard let lastSong = userRepositories.last else { return }
             self.mixedSound = lastSong


### PR DESCRIPTION
## 작업 내용 (Content)
- material에서 base만 누르고 다른 것들은 '선택 안함'으로 눌렀을 때 옆 곡에 melody, whitenoise가 설정되어 있다면 모두설정된 곡을 playPause하고 base만 설정한 곡으로 넘어간 경우 melody, whitenoise가 플레이되던 현상 수정
-> 이전에 플레이되었던 음원이 audioMangaer()의 player에 그대로 남아있기 때문에 발생한 버그인 것 같습니다. 그래서 음원이 없다면 player에 nil을 할당해줬습니다.

## 기타 사항 (Etc)
- 저번에 수정했던 내용과 비슷한 버그인데 playPause를 눌렀을 시 또다시 발생하여 급히 픽스합니다.
- 비어있는 요소가 1개 일때는 크게 불편하지 않지만, 비어있는 요소가 2개인 곡에서 >>, <<를 이용하여 다음 곡으로 이동할 때 짧은 렉이 걸립니다. 원인은 아직 못찾았습니다.

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #241 

## 관련 사진(Optional)
