### PR TITLE
[feat] #268: Studio뷰로 넘어가는 뷰 수정

### DIFF
--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -178,13 +178,14 @@ extension CDListView {
         VStack(alignment: .leading) {
             NavigationLink(destination: StudioView(rootIsActive: self.$isActive), isActive: self.$isActive) {
                 ZStack {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.relaxBlack)
+                    RoundedRectangle(cornerRadius: 4)
+                        .strokeBorder()
                     VStack {
                         Image(systemName: "plus")
                             .font(Font.system(size: 54, weight: .ultraLight))
                     }
-                    
-                    RoundedRectangle(cornerRadius: 4)
-                        .strokeBorder()
                 }
                 .frame(width: UIScreen.main.bounds.width * 0.43, height: UIScreen.main.bounds.width * 0.43)
                 .foregroundColor(.systemGrey3)


### PR DESCRIPTION
## 작업 내용 (Content)
- StudioButton이 중앙의 + 버튼과 테두리를 클릭 했을시만 화면전환 되는 문제를 영역 전체를 클릭해도 넘어가도록 수정했습니다.

## 기타 사항 (Etc)
- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #268 

## 관련 사진(Optional)

![Simulator Screen Recording - iPhone 14 Pro - 2022-09-14 at 11 38 39](https://user-images.githubusercontent.com/81131715/190046170-c95d9d99-3aef-43d7-87a7-c0b0d286d86f.gif)
