### PR TITLE
[fix] #269 segmentControl 하단 바 크기 수정 및 정렬 수정

### DIFF
--- a/RelaxOn/Views/Kitchen/CustomSegmentControlView.swift
+++ b/RelaxOn/Views/Kitchen/CustomSegmentControlView.swift
@@ -15,18 +15,11 @@ public struct CustomSegmentControlView: View {
 
     // MARK: - General Properties
     private let items: [LocalizedStringKey]
-    
+
     private var selectedItemWidth: CGFloat {
         return itemTitleSizes.count > selection ? itemTitleSizes[selection].width : .zero
     }
-    
-//    private var xSpace: CGFloat {
-//        let itemWidthSum: CGFloat = itemTitleSizes.map { $0.width }.reduce(0, +).rounded()
-//        let space = (segmentSize.width - itemWidthSum) / CGFloat(items.count - 1)
-//        return max(space, 0)
-//
-//    }
-    
+
     // MARK: - Methods
     private func segmentItemView(for index: Int) -> some View {
         guard index < self.items.count else {
@@ -36,7 +29,7 @@ public struct CustomSegmentControlView: View {
         let isSelected = self.selection == index
 
         return Text(items[index])
-            .font(.body)
+            .font(.caption)
             .foregroundColor(isSelected ? .white : .gray)
             .background(BackgroundGeometryReader())
             .onPreferenceChange(SizePreferenceKey.self) {
@@ -52,18 +45,11 @@ public struct CustomSegmentControlView: View {
     }
 
     private func selectedItemHorizontalOffset() -> CGFloat {
-        guard selectedItemWidth != .zero, selection != 0 else { return 20 }
-        // selected Item이전까지의 select된 title의 width값의 합
-        let result = itemTitleSizes
-            .enumerated()
-            .filter { $0.offset < selection }
-            .map { $0.element.width }
-            .reduce(0, +)
+        guard selectedItemWidth != .zero, selection != 0 else { return 30 }
 
-        return 20 + 36 * CGFloat(selection) + result
-//        return result + xSpace * CGFloat(selection)
+        return 30 + (deviceFrame.screenWidth * 0.295) * CGFloat(selection) + ( CGFloat(selection) == 2 ? deviceFrame.screenWidth * 0.03 : 0 )
     }
-    
+
     // MARK: - Life Cycles
     public init(items: [String],
                 selection: Binding<Int>) {
@@ -80,23 +66,22 @@ public struct CustomSegmentControlView: View {
                     HStack(spacing: 0) {
                         ForEach(0 ..< items.count, id: \.self) { index in
                             segmentItemView(for: index)
-                                .padding(.leading, index == 0 ? 20 : 36)
+                                .padding(.leading,
+                                         index == 0 ? 58 : ( index == 1 ? deviceFrame.screenWidth * 0.19 : deviceFrame.screenWidth * 0.16 ))
                         }
                     }
-                    .padding(.bottom, 2)
+                    .padding(.bottom, 5)
 
                     // 선택된 요소 밑줄
                     Rectangle()
                         .foregroundColor(.white)
-                        .frame(width: selectedItemWidth, height: 2)
+                        .frame(width: 88, height: 1)
                         .offset(x: selectedItemHorizontalOffset(), y: 0)
                         .animation(Animation.linear(duration: 0.3), value: selectedItemWidth)
 
                 }
-//                .padding(.horizontal, 36)
                 Spacer()
             }
-
         }
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- StudioView 및 OnboardingView에서 사용되는 SegmentControl의 하단 바 크기 수정 및 정렬을 수정했습니다.
- 좌측이 아이폰 14, 우측이 아이폰 SE3세대로 기기간 비율도 최대한 맞췄습니다.

## 기타 사항 (Etc)
- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #269 

## 관련 사진(Optional)
<p align="left">
  <img width="250" alt="스크린샷1" src="https://user-images.githubusercontent.com/81131715/190204263-7589b536-9b9d-4416-af68-29917c74e718.gif">
  <img width="250" alt="스크린샷2" src="https://user-images.githubusercontent.com/81131715/190204339-63f1111c-0aa1-47f0-bf32-531b2deb15d7.gif">
</p>