### PR TITLE
[Fix] #280 : CD 제작 시, CD Cover Image의 Background 색상 변경

### DIFF
--- a/RelaxOn/Views/Home/Music/MusicView.swift
+++ b/RelaxOn/Views/Home/Music/MusicView.swift
@@ -57,7 +57,7 @@ struct MusicView: View {
                     VStack(spacing: 0) {
                         if let selectedImageNames = viewModel.mixedSound?.getImageName() {
                             CDCoverImageView(selectedImageNames: selectedImageNames)
-                                .addWhiteBackground()
+                                .addDefaultBackground()
                                 .padding(.horizontal, 20)
                                 .frame(width: cdViewWidth, height: cdViewWidth - 40)
                                 .aspectRatio(1, contentMode: .fit)

--- a/RelaxOn/Views/Kitchen/CDCoverImageView.swift
+++ b/RelaxOn/Views/Kitchen/CDCoverImageView.swift
@@ -37,12 +37,13 @@ extension CDCoverImageView {
     }
     
     @ViewBuilder
-    func addWhiteBackground() -> some View {
+    func addDefaultBackground() -> some View {
         self
             .background {
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(.white)
+                Rectangle()
+                    .fill(.white.opacity(0.2))
             }
+            .cornerRadius(4)
             .clipped()
     }
     
@@ -54,6 +55,7 @@ extension CDCoverImageView {
         } else {
             Image(imageName)
                 .resizable()
+                
         }
     }
 }

--- a/RelaxOn/Views/Kitchen/StudioView.swift
+++ b/RelaxOn/Views/Kitchen/StudioView.swift
@@ -70,7 +70,7 @@ struct StudioView: View {
                 }
                 
                 CDCoverImageView(selectedImageNames: selectedImageNames)
-                    .addWhiteBackground()
+                    .addDefaultBackground()
                     .DeviceFrame()
                 
                 CustomSegmentControlView(items: items, selection: $select)


### PR DESCRIPTION
## 작업 내용 (Content)
- StudioView에서 CD Cover Image의 기본 Background 색상을 변경하였습니다.
- `addWhiteBackground()` 가 `addDefaultBackground()`로 변경되었습니다.

## 기타 사항 (Etc)
- Figma에서는 블러수치가 적용되어있지만, 블러 적용 시, 오히려 Figma와 다른 색상으로 표시되어 블러를 적용하지 않았습니다.

## Close Issues
Close #280

## 관련 사진(Optional)
**CD Image Cover만 봐주세요!**

변경 전
<img src="https://user-images.githubusercontent.com/47404421/190321382-b61bf9f6-39b6-492f-8557-4c9670e5a339.png" width="250"/>

변경 후
<img src="https://user-images.githubusercontent.com/47404421/190321310-3284a429-e18e-4a0b-afaa-1a05ff5e7100.png" width="250"/>
