### PR TITLE
[fix] MusicView에서 볼륨을 조절할 때 의도하지 않은 애니메이션이 적용되던 현상 수정

### DIFF
--- a/RelaxOn/Views/Home/Music/MusicView.swift
+++ b/RelaxOn/Views/Home/Music/MusicView.swift
@@ -21,6 +21,7 @@ struct MusicView: View {
     @State private var cdNameFontSize = 28.0
     @State private var musicControlButtonWidth = 49.0
     @State private var musicPlayButtonWidth = 44.0
+    @State private var isEditingVolume = false
     
     var timerManager = TimerManager.shared
     
@@ -80,61 +81,66 @@ struct MusicView: View {
                 
                 VolumeControlView(showVolumeControl: $showVolumeControl,
                                   audioVolumes: $audioVolumes,
-                                  userRepositoriesState: $userRepositoriesState)
+                                  userRepositoriesState: $userRepositoriesState,
+                                  isEditingVolume: $isEditingVolume)
                 .cornerRadius(20)
                 .offset(y: offsetYOfControlView)
                 .gesture(
                     DragGesture()
                         .onChanged { value in
-                            let draggedHeight = value.translation.height
-                            let deviceHalfHeight = UIScreen.main.bounds.height * 0.5
-                            let gradient = draggedHeight / deviceHalfHeight
-                            offsetYOfControlView += draggedHeight / 5
-                            
-                            if value.location.y > UIScreen.main.bounds.height * 0.82 {
-                                return
-                            } else if offsetYOfControlView == deviceHalfHeight {
-                                return
-                            } else {
-                                if value.translation.height > 0 {
-                                    cdViewWidth = UIScreen.main.bounds.width * 0.54 * gradient + UIScreen.main.bounds.width * 0.46
-                                    cdViewHeight = UIScreen.main.bounds.height * 0.3 * gradient + UIScreen.main.bounds.height * 0.33
-                                    cdNameFontSize = 6.0 * gradient + 22.0
-                                    musicPlayButtonWidth = 18 * gradient + 26.0
-                                    musicControlButtonWidth = 26 * gradient + 23
+                            if !isEditingVolume {
+                                let draggedHeight = value.translation.height
+                                let deviceHalfHeight = UIScreen.main.bounds.height * 0.5
+                                let gradient = draggedHeight / deviceHalfHeight
+                                offsetYOfControlView += draggedHeight / 5
+                                
+                                if value.location.y > UIScreen.main.bounds.height * 0.82 {
+                                    return
+                                } else if offsetYOfControlView == deviceHalfHeight {
+                                    return
                                 } else {
-                                    cdViewWidth = UIScreen.main.bounds.width * 0.54 * (gradient) + UIScreen.main.bounds.width
-                                    cdViewHeight = UIScreen.main.bounds.height * 0.3 * (gradient) + UIScreen.main.bounds.height * 0.63
-                                    cdNameFontSize = 6.0 * (gradient) + 28.0
-                                    musicPlayButtonWidth = 18.0 * (gradient) + 44
-                                    musicControlButtonWidth = 26 * (gradient) + 49
+                                    if value.translation.height > 0 {
+                                        cdViewWidth = UIScreen.main.bounds.width * 0.54 * gradient + UIScreen.main.bounds.width * 0.46
+                                        cdViewHeight = UIScreen.main.bounds.height * 0.3 * gradient + UIScreen.main.bounds.height * 0.33
+                                        cdNameFontSize = 6.0 * gradient + 22.0
+                                        musicPlayButtonWidth = 18 * gradient + 26.0
+                                        musicControlButtonWidth = 26 * gradient + 23
+                                    } else {
+                                        cdViewWidth = UIScreen.main.bounds.width * 0.54 * (gradient) + UIScreen.main.bounds.width
+                                        cdViewHeight = UIScreen.main.bounds.height * 0.3 * (gradient) + UIScreen.main.bounds.height * 0.63
+                                        cdNameFontSize = 6.0 * (gradient) + 28.0
+                                        musicPlayButtonWidth = 18.0 * (gradient) + 44
+                                        musicControlButtonWidth = 26 * (gradient) + 49
+                                    }
                                 }
                             }
                         }
                         .onEnded { value in
-                            withAnimation(.spring()) {
-                                let draggedHeight = value.predictedEndTranslation.height
-                                if draggedHeight < -30 {
-                                    offsetYOfControlView = UIScreen.main.bounds.height * 0.46
-                                    cdViewWidth = UIScreen.main.bounds.width * 0.46
-                                    cdViewHeight = UIScreen.main.bounds.height * 0.33
-                                    cdNameFontSize = 22.0
-                                    musicPlayButtonWidth = 26.0
-                                    musicControlButtonWidth = 23
-                                } else if draggedHeight > 30 {
-                                    offsetYOfControlView = UIScreen.main.bounds.height * 0.83
-                                    cdViewWidth = UIScreen.main.bounds.width
-                                    cdViewHeight = UIScreen.main.bounds.height * 0.63
-                                    cdNameFontSize = 28.0
-                                    musicPlayButtonWidth = 44
-                                    musicControlButtonWidth = 49
-                                } else {
-                                    offsetYOfControlView = UIScreen.main.bounds.height * 0.83
-                                    cdViewWidth = UIScreen.main.bounds.width
-                                    cdViewHeight = UIScreen.main.bounds.height * 0.63
-                                    cdNameFontSize = 28.0
-                                    musicPlayButtonWidth = 44
-                                    musicControlButtonWidth = 49
+                            if !isEditingVolume {
+                                withAnimation(.spring()) {
+                                    let draggedHeight = value.predictedEndTranslation.height
+                                    if draggedHeight < -30 {
+                                        offsetYOfControlView = UIScreen.main.bounds.height * 0.46
+                                        cdViewWidth = UIScreen.main.bounds.width * 0.46
+                                        cdViewHeight = UIScreen.main.bounds.height * 0.33
+                                        cdNameFontSize = 22.0
+                                        musicPlayButtonWidth = 26.0
+                                        musicControlButtonWidth = 23
+                                    } else if draggedHeight > 30 {
+                                        offsetYOfControlView = UIScreen.main.bounds.height * 0.83
+                                        cdViewWidth = UIScreen.main.bounds.width
+                                        cdViewHeight = UIScreen.main.bounds.height * 0.63
+                                        cdNameFontSize = 28.0
+                                        musicPlayButtonWidth = 44
+                                        musicControlButtonWidth = 49
+                                    } else {
+                                        offsetYOfControlView = UIScreen.main.bounds.height * 0.83
+                                        cdViewWidth = UIScreen.main.bounds.width
+                                        cdViewHeight = UIScreen.main.bounds.height * 0.63
+                                        cdNameFontSize = 28.0
+                                        musicPlayButtonWidth = 44
+                                        musicControlButtonWidth = 49
+                                    }
                                 }
                             }
                         }

--- a/RelaxOn/Views/Home/Music/VolumeControlView.swift
+++ b/RelaxOn/Views/Home/Music/VolumeControlView.swift
@@ -13,6 +13,7 @@ struct VolumeControlView: View {
     @Binding var showVolumeControl: Bool
     @Binding var audioVolumes: (baseVolume: Float, melodyVolume: Float, whiteNoiseVolume: Float)
     @Binding var userRepositoriesState: [MixedSound]
+    @Binding var isEditingVolume: Bool
     @EnvironmentObject var viewModel: MusicViewModel
     
     // MARK: - General Properties
@@ -147,6 +148,9 @@ extension VolumeControlView {
                         Slider(value: $audioVolumes.baseVolume, in: 0...1) { editing in
                             if !editing {
                                 saveNewVolume()
+                                self.isEditingVolume = false
+                            } else {
+                                self.isEditingVolume = true
                             }
                         }
                         .background(.black)
@@ -163,6 +167,9 @@ extension VolumeControlView {
                         Slider(value: $audioVolumes.melodyVolume, in: 0...1) { editing in
                             if !editing {
                                 saveNewVolume()
+                                self.isEditingVolume = false
+                            } else {
+                                self.isEditingVolume = true
                             }
                         }
                         .background(.black)
@@ -179,6 +186,9 @@ extension VolumeControlView {
                         Slider(value: $audioVolumes.whiteNoiseVolume, in: 0...1) { editing in
                             if !editing {
                                 saveNewVolume()
+                                self.isEditingVolume = false
+                            } else {
+                                self.isEditingVolume = true
                             }
                         }
                         .background(.black)


### PR DESCRIPTION
## 작업 내용 (Content)
- volume이 조절되는 순간에 bool값을 줘서 조절중에는 애니메이션이 작동하지 않도록 하였습니다.

## 기타 사항 (Etc)
- 코드가 깔끔한 것 같지는 않아 추후에 리팩토링이 필요해 보입니다.

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #300 

## 관련 사진(Optional)
![Simulator Screen Recording - iPhone 13 - 2022-09-16 at 19 22 27](https://user-images.githubusercontent.com/91456952/190618147-2f86f753-3b4f-468e-991f-bcf04de41b2a.gif)
