### PR TITLE
[fix] CDLibrary에서 음원 delete시 delete 상태가 바로 적용되지 않던 현상 수정

### DIFF
--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -122,9 +122,11 @@ struct CDListView: View {
                 selectedMixedSoundIds.forEach { id in
                     if let index = userRepositories.firstIndex(where: {$0.id == id}) {
                         userRepositories.remove(at: index)
+                        
                         viewModel.sendMessage(key: "list", userRepositoriesState.map{mixedSound in mixedSound.name})
                     }
                 }
+                userRepositoriesState = userRepositories
                 let data = getEncodedData(data: userRepositories)
                 UserDefaults.standard.set(data, forKey: "recipes")
                 selectedMixedSoundIds = []


### PR DESCRIPTION
## 작업 내용 (Content)
- CDLibrary에서 음원 delete시 delete 상태가 바로 적용되지 않던 현상 수정

## 기타 사항 (Etc)
- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #302

## 관련 사진(Optional)
![Simulator Screen Recording - iPhone 13 - 2022-09-16 at 19 43 52](https://user-images.githubusercontent.com/91456952/190621942-75c70682-fa39-484c-a9fc-5117417821c5.gif)


