### PR TITLE
[fix] studio에서 입력한 볼륨과 실제 생성된 볼륨이 다른 현상 & 앱내 컨트롤러 오류 수정

### DIFF
--- a/RelaxOn/Model/SoundType.swift
+++ b/RelaxOn/Model/SoundType.swift
@@ -58,7 +58,7 @@ enum BaseSound: String, CaseIterable {
             Sound(id: $0.offset + 1,
                   name: $0.element.displayName,
                   soundType: .base,
-                  audioVolume: 0.8,
+                  audioVolume: 0.5,
                   fileName: $0.element.fileName)
         }
     }
@@ -84,7 +84,7 @@ enum MelodySound: String, CaseIterable {
             Sound(id: $0.offset + 1 + 10,
                   name: $0.element.displayName,
                   soundType: .melody,
-                  audioVolume: 0.8,
+                  audioVolume: 0.5,
                   fileName: $0.element.fileName)
         }
     }
@@ -110,7 +110,7 @@ enum WhiteNoiseSound: String, CaseIterable {
             Sound(id: $0.offset + 1 + 20,
                   name: $0.element.displayName,
                   soundType: .whiteNoise,
-                  audioVolume: 0.8,
+                  audioVolume: 0.5,
                   fileName: $0.element.fileName)
         }
     }

--- a/RelaxOn/Views/Kitchen/CDListView.swift
+++ b/RelaxOn/Views/Kitchen/CDListView.swift
@@ -122,11 +122,15 @@ struct CDListView: View {
                 selectedMixedSoundIds.forEach { id in
                     if let index = userRepositories.firstIndex(where: {$0.id == id}) {
                         userRepositories.remove(at: index)
+                        if id == viewModel.mixedSound?.id {
+                            viewModel.mixedSound = nil
+                        }
                         
                         viewModel.sendMessage(key: "list", userRepositoriesState.map{mixedSound in mixedSound.name})
                     }
                 }
                 userRepositoriesState = userRepositories
+                
                 let data = getEncodedData(data: userRepositories)
                 UserDefaults.standard.set(data, forKey: "recipes")
                 selectedMixedSoundIds = []


### PR DESCRIPTION
## 작업 내용 (Content)
- studio에서 슬라이더에 변화를 주지 않는 경우 defualt값인 50이 저장되어야 하는데 soundList의 default값인 0.8이 저장되는 현상을 수정 했습니다.
- 재생중인 노래가 삭제되었을 때 앱내컨트롤러에 해당 음원이 남아있고 음악이 계속 재생되는 현상이 있어서 이를 수정하였습니다.

## 기타 사항 (Etc)
- 야매 방식이라 추후 리팩토링이 필요해 보입니다. 볼륨 슬라이더에 변화가 없으면 저장되지 않는 현상에 대한 수정이 필요해 보입니다. @coby5502 아님 이대로 둬도 괜찮을까요?

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #304 
Close #306 

## 관련 사진(Optional)
