### PR TITLE
[fix] musicView & 앱내 컨트롤러 오류 수정

### DIFF
--- a/RelaxOn/Views/Home/Music/MusicView.swift
+++ b/RelaxOn/Views/Home/Music/MusicView.swift
@@ -261,6 +261,7 @@ extension MusicView {
                     let data = getEncodedData(data: userRepositories)
                     UserDefaultsManager.shared.recipes = data
                     userRepositoriesState = userRepositories
+                    viewModel.mixedSound = nil
                     presentationMode.wrappedValue.dismiss()
                 } label: {
                     HStack{

--- a/RelaxOn/Views/Home/Music/MusicViewModel.swift
+++ b/RelaxOn/Views/Home/Music/MusicViewModel.swift
@@ -60,8 +60,9 @@ final class MusicViewModel: NSObject, ObservableObject {
     
     @Published var mixedSound: MixedSound? {
         didSet {
-            startPlayer()
-            
+            if oldValue?.name != mixedSound?.name {
+                startPlayer()
+            }
         }
     }
     

--- a/RelaxOn/Views/Kitchen/StudioView.swift
+++ b/RelaxOn/Views/Kitchen/StudioView.swift
@@ -191,6 +191,7 @@ extension StudioView {
             }.padding(.horizontal, 15)
         }
         .onAppear {
+            viewModel.isPlaying = false
             if self.viewType == .onboarding {
                 withAnimation(.default) {
                     stepBarWidth = deviceFrame.screenWidth * CGFloat( Double(select + 1) * 0.333 )


### PR DESCRIPTION
## 작업 내용 (Content)
- 같은 음원에 앱내 컨트롤러 or 해당 음원 card 통해서 음원에 다시 들어갈때 노래가 재시작 되는 현상
- musicView에서 플레이중인 음악을 삭제했음에도 노래가 재생되고 앱내 컨트롤러에 해당 음악 정보가 남아있는 정보 수정 (mixedSound에 nil 대입)

## 기타 사항 (Etc)
- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #308  
Close #307 

## 관련 사진(Optional)
![Simulator Screen Recording - iPhone 13 - 2022-09-16 at 20 30 52](https://user-images.githubusercontent.com/91456952/190629473-da62e4a4-81b5-45fb-9708-2940f39b74a1.gif)

