### PR TITLE
[fix] emptySoun를 .base 타입으로 생성하여 생기는 오류

### DIFF
--- a/LockScreenWidgetExtension/LockScreenWidgetExtension.swift
+++ b/LockScreenWidgetExtension/LockScreenWidgetExtension.swift
@@ -27,7 +27,6 @@ struct Provider: TimelineProvider {
         if var timerData = UserDefaults(suiteName: WidgetManager.suiteName)!.value(forKey: WidgetManager.lockScreenWidgetData) as? Double {
             let endDate = Calendar.current.date(byAdding: .second, value: Int(timerData), to: currentDate)
             var addedSeconds: Double = 0
-            print("됐음둥1", timerData)
             while timerData >= 0 {
                 let entry = CDLockScreenWidgetEntry(date: currentDate + addedSeconds, startDate: currentDate, endDate: endDate ?? Date(), settedSeconds: timerData)
                 entries.append(entry)
@@ -49,7 +48,6 @@ struct Provider: TimelineProvider {
             entries.append(entry)
             let timeline = Timeline(entries: entries, policy: .never)
             completion(timeline)
-            print("안됐음둥")
         }
     }
 }

--- a/RelaxOn/Model/MixedSound.swift
+++ b/RelaxOn/Model/MixedSound.swift
@@ -41,9 +41,9 @@ extension MixedSound {
     }
     
     static let preview = MixedSound(name: "Preview",
-                                    baseSound: Sound.empty(0),
-                                    melodySound: Sound.empty(1),
-                                    whiteNoiseSound: Sound.empty(2),
+                                    baseSound: Sound.empty(0, .base),
+                                    melodySound: Sound.empty(1, .melody),
+                                    whiteNoiseSound: Sound.empty(2, .whiteNoise),
                                     fileName: "Recipe1")
     
     func getImageName() -> (String, String, String) {
@@ -56,8 +56,8 @@ extension MixedSound {
 }
 
 let emptyMixedSound = MixedSound(name: "empty",
-                                 baseSound: Sound.empty(0),
-                                 melodySound: Sound.empty(1),
-                                 whiteNoiseSound: Sound.empty(2),
+                                 baseSound: Sound.empty(0, .base),
+                                 melodySound: Sound.empty(1, .melody),
+                                 whiteNoiseSound: Sound.empty(2, .whiteNoise),
                                  fileName: "")
 

--- a/RelaxOn/Model/Sound.swift
+++ b/RelaxOn/Model/Sound.swift
@@ -14,11 +14,11 @@ struct Sound: Identifiable, Codable {
     var audioVolume: Float
     let fileName: String
     
-    static let empty: (Int) -> Sound = {
+    static let empty: (Int, SoundType) -> Sound = {
         return Sound(id: $0 * 10,
                      name: "Empty",
-                     soundType: .base,
-                     audioVolume: 0.8,
+                     soundType: $1,
+                     audioVolume: 0.5,
                      fileName: "")
     }
 }

--- a/RelaxOn/Model/SoundType.swift
+++ b/RelaxOn/Model/SoundType.swift
@@ -13,7 +13,7 @@ enum SoundType: String, CaseIterable, Codable {
     case whiteNoise
     
     var soundList: [Sound] {
-        var soundList = [Sound.empty(self.index)]
+        var soundList = [Sound.empty(self.index, self)]
         switch self {
         case .base:
             soundList.append(contentsOf: BaseSound.soundList)

--- a/RelaxOn/Views/Kitchen/SoundCardView.swift
+++ b/RelaxOn/Views/Kitchen/SoundCardView.swift
@@ -75,7 +75,7 @@ struct SoundCardView: View {
 struct SoundCard_Previews: PreviewProvider {
     static var previews: some View {
         SoundCardView(soundFileName : "base_default",
-                      data: SoundType.base.soundList.first ?? Sound.empty(0),
+                      data: SoundType.base.soundList.first ?? Sound.empty(0, .base),
                   callback: {_,_  in },
                   selectedID: "")
         .background(Color.backgroundColor)


### PR DESCRIPTION
## 작업 내용 (Content)
- melody, whiteNois를 empty로 한 경우 .base 타입이 부여되었기 때문에 base의 음량을 조절해도 slider가 같이 움직이는 버그 해결
- 파라미터 추가

## 기타 사항 (Etc)
- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #310 

## 관련 사진(Optional)
