### PR TITLE
[fix] #326 : Change Xcode Version in GitAction

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -2,9 +2,9 @@ name: iOS Build Action
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "release/2.3.0"]
   pull_request:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "release/2.3.0"]
 
 jobs:
   build:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -10,10 +10,11 @@ jobs:
   build:
     name: Build and Test default scheme using any available iPhone simulator
     runs-on: macos-12
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '14.0'
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")
@@ -30,4 +31,4 @@ jobs:
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=iPhone 13,OS=15.5"
+          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=iPhone 13,OS=16.0"


### PR DESCRIPTION
## 작업 내용 (Content)
- GitAction에서 실행되는 ios.yml 파일을 수정하였습니다.
- 주요변경 사항
    - `steps`에`maxim-lobanov/setup-xcode@v1`를 추가하여, 빌드를 Xcode 14.0 에서 진행할 수 있도록 하였습니다. [fileChanged](https://github.com/M1zz/RelaxOn/pull/327/files#diff-fc40e39603744467ec4d9d7cb6c3bd67756ec09c037d03f3655904fc1c6bcfdaR17)
    - 실행되는 Simulator의 iOS 버전을 iOS 16으로 수정하였습니다.  [fileChanged](https://github.com/M1zz/RelaxOn/pull/327/files#diff-fc40e39603744467ec4d9d7cb6c3bd67756ec09c037d03f3655904fc1c6bcfdaR34)

## 기타 사항 (Etc)
- `actions/checkout@v3`의 `name`이 사용되고 있지 않아 수정하였습니다.
- 현재 `main`과 `develop` 이름의 branch만 GitAction을 수행하도록 되어있습니다.
    이를 매번 현재 작업이 진행중인 브랜치에서도 작동하도록 하는 것에 대해 여러분들의 의견이 궁금합니다.

## Close Issues
Close #326 