### PR TITLE
[refactor] #329 : WatchKit Extension의 View들을 ViewModel과 1대1 대응하도록 만들기

### DIFF
--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		2125F1B928CE0299007BAB85 /* PageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2125F1B828CE0299007BAB85 /* PageView.swift */; };
 		2125F1BB28CE02BE007BAB85 /* CDPlayerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2125F1BA28CE02BD007BAB85 /* CDPlayerManager.swift */; };
 		2125F1BD28CE02D7007BAB85 /* WatchConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2125F1BC28CE02D7007BAB85 /* WatchConnectivityManager.swift */; };
+		214BE8D228E3208C009C853F /* CDListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214BE8D128E3208C009C853F /* CDListViewModel.swift */; };
 		216057DB28BD4DBF0032A5AC /* CDListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216057DA28BD4DBF0032A5AC /* CDListView.swift */; };
 		216057DD28BD4E760032A5AC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 216057DC28BD4E760032A5AC /* Assets.xcassets */; };
 		216057DE28BD4EA40032A5AC /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753494F28B748C80055F7CA /* Color+Extension.swift */; };
@@ -243,6 +244,7 @@
 		2125F1B828CE0299007BAB85 /* PageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageView.swift; sourceTree = "<group>"; };
 		2125F1BA28CE02BD007BAB85 /* CDPlayerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDPlayerManager.swift; sourceTree = "<group>"; };
 		2125F1BC28CE02D7007BAB85 /* WatchConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityManager.swift; sourceTree = "<group>"; };
+		214BE8D128E3208C009C853F /* CDListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDListViewModel.swift; sourceTree = "<group>"; };
 		216057DA28BD4DBF0032A5AC /* CDListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDListView.swift; sourceTree = "<group>"; };
 		216057DC28BD4E760032A5AC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2193315F28D2B1A5006D1E75 /* VolumeSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeSliderView.swift; sourceTree = "<group>"; };
@@ -411,6 +413,7 @@
 			children = (
 				2125F1B828CE0299007BAB85 /* PageView.swift */,
 				216057DA28BD4DBF0032A5AC /* CDListView.swift */,
+				214BE8D128E3208C009C853F /* CDListViewModel.swift */,
 				21B7A65C28A31DE700E90744 /* CDPlayerView.swift */,
 			);
 			path = Views;
@@ -1088,6 +1091,7 @@
 				21B7A66328A31DE700E90744 /* ComplicationController.swift in Sources */,
 				21B7A65B28A31DE700E90744 /* RelaxOnApp.swift in Sources */,
 				2125F1BD28CE02D7007BAB85 /* WatchConnectivityManager.swift in Sources */,
+				214BE8D228E3208C009C853F /* CDListViewModel.swift in Sources */,
 				21B7A66128A31DE700E90744 /* NotificationView.swift in Sources */,
 				2125F1BB28CE02BE007BAB85 /* CDPlayerManager.swift in Sources */,
 				2125F1B928CE0299007BAB85 /* PageView.swift in Sources */,

--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		2125F1BB28CE02BE007BAB85 /* CDPlayerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2125F1BA28CE02BD007BAB85 /* CDPlayerManager.swift */; };
 		2125F1BD28CE02D7007BAB85 /* WatchConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2125F1BC28CE02D7007BAB85 /* WatchConnectivityManager.swift */; };
 		214BE8D228E3208C009C853F /* CDListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214BE8D128E3208C009C853F /* CDListViewModel.swift */; };
+		214BE8D428E32322009C853F /* CDPlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214BE8D328E32322009C853F /* CDPlayerViewModel.swift */; };
 		216057DB28BD4DBF0032A5AC /* CDListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216057DA28BD4DBF0032A5AC /* CDListView.swift */; };
 		216057DD28BD4E760032A5AC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 216057DC28BD4E760032A5AC /* Assets.xcassets */; };
 		216057DE28BD4EA40032A5AC /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753494F28B748C80055F7CA /* Color+Extension.swift */; };
@@ -245,6 +246,7 @@
 		2125F1BA28CE02BD007BAB85 /* CDPlayerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDPlayerManager.swift; sourceTree = "<group>"; };
 		2125F1BC28CE02D7007BAB85 /* WatchConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityManager.swift; sourceTree = "<group>"; };
 		214BE8D128E3208C009C853F /* CDListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDListViewModel.swift; sourceTree = "<group>"; };
+		214BE8D328E32322009C853F /* CDPlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDPlayerViewModel.swift; sourceTree = "<group>"; };
 		216057DA28BD4DBF0032A5AC /* CDListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDListView.swift; sourceTree = "<group>"; };
 		216057DC28BD4E760032A5AC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2193315F28D2B1A5006D1E75 /* VolumeSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeSliderView.swift; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 				216057DA28BD4DBF0032A5AC /* CDListView.swift */,
 				214BE8D128E3208C009C853F /* CDListViewModel.swift */,
 				21B7A65C28A31DE700E90744 /* CDPlayerView.swift */,
+				214BE8D328E32322009C853F /* CDPlayerViewModel.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1087,6 +1090,7 @@
 			files = (
 				21B7A65F28A31DE700E90744 /* NotificationController.swift in Sources */,
 				216057DE28BD4EA40032A5AC /* Color+Extension.swift in Sources */,
+				214BE8D428E32322009C853F /* CDPlayerViewModel.swift in Sources */,
 				21B7A65D28A31DE700E90744 /* CDPlayerView.swift in Sources */,
 				21B7A66328A31DE700E90744 /* ComplicationController.swift in Sources */,
 				21B7A65B28A31DE700E90744 /* RelaxOnApp.swift in Sources */,

--- a/RelaxOnWatch WatchKit Extension/Views/CDListView.swift
+++ b/RelaxOnWatch WatchKit Extension/Views/CDListView.swift
@@ -25,10 +25,7 @@ struct CDListView: View {
                             viewModel.selectCD(of: cdIndex)
                             tabSelection = 1
                         } label: {
-                            Text(viewModel.CDList[cdIndex])
-                                .foregroundColor(viewModel.getCDColor(cdIndex))
-                                .font(.system(size: 18))
-                                .padding(10)
+                            CDTitle(of: cdIndex)
                         }
                         .buttonStyle(.plain)
                         
@@ -42,6 +39,16 @@ struct CDListView: View {
         }
         .navigationTitle("Playlist")
         .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+extension CDListView {
+    @ViewBuilder
+    func CDTitle(of cdIndex: Int) -> some View {
+        Text(viewModel.CDList[cdIndex])
+            .foregroundColor(viewModel.getCDColor(cdIndex))
+            .font(.system(size: 18))
+            .padding(10)
     }
 }
 

--- a/RelaxOnWatch WatchKit Extension/Views/CDListView.swift
+++ b/RelaxOnWatch WatchKit Extension/Views/CDListView.swift
@@ -8,31 +8,25 @@
 import SwiftUI
 
 struct CDListView: View {
-    @ObservedObject var watchConnectivityManager: WatchConnectivityManager
     @Binding var tabSelection: Int
-    @State var selectedCDIndex = -1
+    @ObservedObject var viewModel = CDListViewModel()
     
     var body: some View {
-        
         VStack {
             ScrollView {
-                VStack (alignment: .leading, spacing: 0) {
-                    
-                    ForEach(watchConnectivityManager.cdList.indices, id: \.self) { cdIndex in
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(viewModel.CDList.indices, id: \.self) { cdIndex in
                         
                         if cdIndex == 0 {
                             Divider()
                         }
                         
-                        Button(action: {
-                            CDPlayerManager.shared.currentCDName = watchConnectivityManager.cdList[cdIndex]
-                            WatchConnectivityManager.shared.sendMessage(key: "title", CDPlayerManager.shared.currentCDName)
-                            CDPlayerManager.shared.isPlaying = true
-                            selectedCDIndex = cdIndex
+                        Button {
+                            viewModel.selectCD(of: cdIndex)
                             tabSelection = 1
-                        }) {
-                            Text(watchConnectivityManager.cdList[cdIndex])
-                                .foregroundColor(WatchConnectivityManager.shared.cdList[cdIndex] == CDPlayerManager.shared.currentCDName ? Color.relaxDimPurple : .white)
+                        } label: {
+                            Text(viewModel.CDList[cdIndex])
+                                .foregroundColor(viewModel.getCDColor(cdIndex))
                                 .font(.system(size: 18))
                                 .padding(10)
                         }
@@ -44,7 +38,7 @@ struct CDListView: View {
             }
         }
         .onAppear {
-            WatchConnectivityManager.shared.sendMessage(key: "list", "request")
+            viewModel.getCDList()
         }
         .navigationTitle("Playlist")
         .navigationBarTitleDisplayMode(.inline)
@@ -53,6 +47,6 @@ struct CDListView: View {
 
 struct CDListView_Previews: PreviewProvider {
     static var previews: some View {
-        CDListView(watchConnectivityManager: WatchConnectivityManager.shared, tabSelection: .constant(0))
+        CDListView(tabSelection: .constant(0))
     }
 }

--- a/RelaxOnWatch WatchKit Extension/Views/CDListViewModel.swift
+++ b/RelaxOnWatch WatchKit Extension/Views/CDListViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  CDListViewModel.swift
+//  RelaxOnWatch WatchKit Extension
+//
+//  Created by Minkyeong Ko on 2022/09/27.
+//
+
+import Foundation
+import SwiftUI
+
+final class CDListViewModel: ObservableObject {
+    var cdManager = CDPlayerManager.shared
+    var wcManager = WatchConnectivityManager.shared
+    
+    @Published var CDList: [String] = WatchConnectivityManager.shared.cdList
+    
+    func selectCD(of currentCDIndex: Int) {
+        cdManager.currentCDName = wcManager.cdList[currentCDIndex]
+        wcManager.sendMessage(key: "title", cdManager.currentCDName)
+        cdManager.isPlaying = true
+    }
+    
+    func getCDColor(_ currentCdIndex: Int) -> Color {
+        return wcManager.cdList[currentCdIndex] == cdManager.currentCDName ? Color.relaxDimPurple : .white
+    }
+    
+    func getCDList() {
+        wcManager.sendMessage(key: "list", "request")
+    }
+}

--- a/RelaxOnWatch WatchKit Extension/Views/CDListViewModel.swift
+++ b/RelaxOnWatch WatchKit Extension/Views/CDListViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by Minkyeong Ko on 2022/09/27.
 //
 
-import Foundation
 import SwiftUI
 
 final class CDListViewModel: ObservableObject {

--- a/RelaxOnWatch WatchKit Extension/Views/CDListViewModel.swift
+++ b/RelaxOnWatch WatchKit Extension/Views/CDListViewModel.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 final class CDListViewModel: ObservableObject {
-    var cdManager = CDPlayerManager.shared
-    var wcManager = WatchConnectivityManager.shared
+    let cdManager = CDPlayerManager.shared
+    let wcManager = WatchConnectivityManager.shared
     
     @Published var CDList: [String] = WatchConnectivityManager.shared.cdList
     

--- a/RelaxOnWatch WatchKit Extension/Views/CDPlayerView.swift
+++ b/RelaxOnWatch WatchKit Extension/Views/CDPlayerView.swift
@@ -8,8 +8,7 @@
 import SwiftUI
 
 struct CDPlayerView: View {
-    @ObservedObject var watchConnectivityManager: WatchConnectivityManager
-    @ObservedObject var cdPlayerManager = CDPlayerManager.shared
+    @ObservedObject var viewModel = CDPlayerViewModel()
     @State var volume = 50.0
     
     var body: some View {
@@ -20,66 +19,66 @@ struct CDPlayerView: View {
                 .blur(radius: 10)
             
             VStack {
-                Text(cdPlayerManager.currentCDName)
+                Text(viewModel.currentCDName)
                 
                 HStack {
-                    Button(action: {
-                        cdPlayerManager.playPrevious()
-                    }) {
+                    Button {
+                        viewModel.playPreviouse()
+                    } label: {
                         Image(systemName: "backward.end")
                             .font(.system(size: 20, weight: .medium))
                     }
-                    .disabled(cdPlayerManager.currentCDName == "")
+                    .disabled(viewModel.isPlayerEmpty())
                     .buttonStyle(.plain)
                     
                     Spacer()
                                     
-                    Button(action: {
-                        cdPlayerManager.playPause()
-                    }) {
+                    Button {
+                        viewModel.playPause()
+                    } label: {
                         ZStack {
                             Circle()
                                 .fill(.black)
                                 .frame(width: 50, height: 50)
-                            Image(systemName: cdPlayerManager.isPlaying ? "pause.fill" : "play.fill")
+                            Image(systemName: viewModel.getIconName())
                                 .font(.system(size: 30))
                         }
                     }
-                    .disabled(cdPlayerManager.currentCDName == "")
+                    .disabled(viewModel.isPlayerEmpty())
                     .buttonStyle(.plain)
                     
                     Spacer()
                     
-                    Button(action: {
-                        cdPlayerManager.playNext()
-                    }) {
+                    Button {
+                        viewModel.playNext()
+                    } label: {
                         Image(systemName: "forward.end")
                             .font(.system(size: 20, weight: .medium))
                     }
-                    .disabled(cdPlayerManager.currentCDName == "")
+                    .disabled(viewModel.isPlayerEmpty())
                     .buttonStyle(.plain)
                 }
                 .padding()
                 
                 Slider(value: Binding(
                     get: {
-                        cdPlayerManager.volume
+                        CDPlayerManager.shared.volume
                     },
                     set: {(newValue) in
-                        cdPlayerManager.changeVolume(volume: newValue)
+                        CDPlayerManager.shared.changeVolume(volume: newValue)
                     }
                 ))
                 .tint(.white)
             }
         }
         .onAppear {
-            cdPlayerManager.requestVolume()
+            viewModel.getSystemVolume()
         }
     }
 }
 
 struct CDPlayerView_Previews: PreviewProvider {
     static var previews: some View {
-        CDPlayerView(watchConnectivityManager: WatchConnectivityManager.shared)
+        CDPlayerView()
     }
 }

--- a/RelaxOnWatch WatchKit Extension/Views/CDPlayerView.swift
+++ b/RelaxOnWatch WatchKit Extension/Views/CDPlayerView.swift
@@ -23,7 +23,7 @@ struct CDPlayerView: View {
                 
                 HStack {
                     Button {
-                        viewModel.playPreviouse()
+                        viewModel.playPrevious()
                     } label: {
                         Image(systemName: "backward.end")
                             .font(.system(size: 20, weight: .medium))

--- a/RelaxOnWatch WatchKit Extension/Views/CDPlayerViewModel.swift
+++ b/RelaxOnWatch WatchKit Extension/Views/CDPlayerViewModel.swift
@@ -17,7 +17,7 @@ final class CDPlayerViewModel: ObservableObject {
         cdPlayerManager.requestVolume()
     }
     
-    func playPreviouse() {
+    func playPrevious() {
         cdPlayerManager.playPrevious()
     }
     

--- a/RelaxOnWatch WatchKit Extension/Views/CDPlayerViewModel.swift
+++ b/RelaxOnWatch WatchKit Extension/Views/CDPlayerViewModel.swift
@@ -1,0 +1,39 @@
+//
+//  CDPlayerViewModel.swift
+//  RelaxOnWatch WatchKit Extension
+//
+//  Created by Minkyeong Ko on 2022/09/27.
+//
+
+import SwiftUI
+
+final class CDPlayerViewModel: ObservableObject {
+    @Published var currentCDName = CDPlayerManager.shared.currentCDName
+    @Published var isPlaying = CDPlayerManager.shared.isPlaying
+    
+    var cdPlayerManager = CDPlayerManager.shared
+    
+    func getSystemVolume() {
+        cdPlayerManager.requestVolume()
+    }
+    
+    func playPreviouse() {
+        cdPlayerManager.playPrevious()
+    }
+    
+    func playPause() {
+        cdPlayerManager.playPause()
+    }
+    
+    func isPlayerEmpty() -> Bool {
+        return currentCDName == ""
+    }
+    
+    func getIconName() -> String {
+        return cdPlayerManager.isPlaying ? "pause.fill" : "play.fill"
+    }
+    
+    func playNext() {
+        cdPlayerManager.playNext()
+    }
+}

--- a/RelaxOnWatch WatchKit Extension/Views/PageView.swift
+++ b/RelaxOnWatch WatchKit Extension/Views/PageView.swift
@@ -14,11 +14,11 @@ struct PageView: View {
     var body: some View {
         TabView(selection: $tabSelection) {
             NavigationView {
-                CDListView(watchConnectivityManager: watchConnectivityManager, tabSelection: $tabSelection)
+                CDListView(tabSelection: $tabSelection)
             }
             .tag(0)
             CDPlayerView(watchConnectivityManager: watchConnectivityManager)
-                .tag(1)
+            .tag(1)
         }
         .animation(Animation.easeInOut, value: tabSelection)
         .transition(.slide)

--- a/RelaxOnWatch WatchKit Extension/Views/PageView.swift
+++ b/RelaxOnWatch WatchKit Extension/Views/PageView.swift
@@ -8,16 +8,13 @@
 import SwiftUI
 
 struct PageView: View {
-    @ObservedObject var watchConnectivityManager = WatchConnectivityManager.shared
     @State var tabSelection = 0
     
     var body: some View {
         TabView(selection: $tabSelection) {
-            NavigationView {
-                CDListView(tabSelection: $tabSelection)
-            }
+            CDListView(tabSelection: $tabSelection)
             .tag(0)
-            CDPlayerView(watchConnectivityManager: watchConnectivityManager)
+            CDPlayerView()
             .tag(1)
         }
         .animation(Animation.easeInOut, value: tabSelection)


### PR DESCRIPTION
## 작업 내용 (Content)
- WatchKit Extension의 CDListView, CDPlayerView에 대응하는 뷰모델을 생성하고 적용하였습니다.

## 기타 사항 (Etc)
- 아직 WatchConnectivityManager와 CDPlayManager가 리팩토링 되지 않아서 완성본은 아니지만, PR을 잘게 쪼개는 것이 좋을 것 같아 우선 뷰모델 분리만 진행하고 PR을 올렸습니다.

## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.

Close #329 

## 관련 사진(Optional)
