### PR TITLE
[refact] #336 : Sound가 Empty인 로직 일부 수정

### DIFF
--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -88,11 +88,11 @@
 		C76BCFEC28DC585700635466 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = C76BCFE528DC585700635466 /* .swiftlint.yml */; };
 		C776B17128B2620000A13052 /* RelaxOnUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C776B17028B2620000A13052 /* RelaxOnUITests.swift */; };
 		C776B17328B2620000A13052 /* RelaxOnUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C776B17228B2620000A13052 /* RelaxOnUITestsLaunchTests.swift */; };
+		C781098D28E34A8400FB2840 /* SoundType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4C25728C242BB0048DCBA /* SoundType.swift */; };
 		C7A50DDC28D08FA000841BC6 /* MusicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50DDB28D08FA000841BC6 /* MusicView.swift */; };
 		C7C4C25028C236D80048DCBA /* Sound.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7C4C24F28C236D80048DCBA /* Sound.xcassets */; };
 		C7C4C25428C238110048DCBA /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7C4C25328C238110048DCBA /* Color.xcassets */; };
 		C7C4C25828C242BB0048DCBA /* SoundType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4C25728C242BB0048DCBA /* SoundType.swift */; };
-		C7C4C25928C243840048DCBA /* SoundType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4C25728C242BB0048DCBA /* SoundType.swift */; };
 		C7C4C25A28C256BF0048DCBA /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753494F28B748C80055F7CA /* Color+Extension.swift */; };
 		C7EC1CA128B783B8006A5860 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753495328B748E20055F7CA /* String+Extension.swift */; };
 		C7EC1CA228B783C7006A5860 /* Float+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753495528B75BD20055F7CA /* Float+Extension.swift */; };
@@ -1175,7 +1175,7 @@
 				CC5AC11F289D15EE00FE847B /* Static.swift in Sources */,
 				C7EC1CA228B783C7006A5860 /* Float+Extension.swift in Sources */,
 				CC5AC125289D160E00FE847B /* AudioManager.swift in Sources */,
-				C7C4C25928C243840048DCBA /* SoundType.swift in Sources */,
+				C781098D28E34A8400FB2840 /* SoundType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1616,6 +1616,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"RelaxOn/Preview Content\"";
 				DEVELOPMENT_TEAM = QGAQ3AY3R3;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QGAQ3AY3R3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RelaxOn/Info.plist;
@@ -1632,6 +1633,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.leeo.LullabyRecipe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = LullabyRecipe;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = LullabyRecipe;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1650,6 +1652,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"RelaxOn/Preview Content\"";
 				DEVELOPMENT_TEAM = QGAQ3AY3R3;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QGAQ3AY3R3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = RelaxOn/Info.plist;
@@ -1666,6 +1669,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.leeo.LullabyRecipe;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = LullabyRecipe;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = LullabyRecipe;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/RelaxOn/Model/MixedSound.swift
+++ b/RelaxOn/Model/MixedSound.swift
@@ -41,9 +41,9 @@ extension MixedSound {
     }
     
     static let preview = MixedSound(name: "Preview",
-                                    baseSound: Sound.empty(0, .base),
-                                    melodySound: Sound.empty(1, .melody),
-                                    whiteNoiseSound: Sound.empty(2, .whiteNoise),
+                                    baseSound: Sound.empty(.base),
+                                    melodySound: Sound.empty(.melody),
+                                    whiteNoiseSound: Sound.empty(.whiteNoise),
                                     fileName: "Recipe1")
     
     func getImageName() -> (String, String, String) {
@@ -56,8 +56,8 @@ extension MixedSound {
 }
 
 let emptyMixedSound = MixedSound(name: "empty",
-                                 baseSound: Sound.empty(0, .base),
-                                 melodySound: Sound.empty(1, .melody),
-                                 whiteNoiseSound: Sound.empty(2, .whiteNoise),
+                                 baseSound: Sound.empty(.base),
+                                 melodySound: Sound.empty(.melody),
+                                 whiteNoiseSound: Sound.empty(.whiteNoise),
                                  fileName: "")
 

--- a/RelaxOn/Model/MixedSound.swift
+++ b/RelaxOn/Model/MixedSound.swift
@@ -25,6 +25,14 @@ struct MixedSound: Identifiable, Codable, Equatable {
         self.fileName = fileName
         self.url = WidgetManager.getURL(id: id)
     }
+    
+    static var empty: MixedSound {
+        MixedSound(name: "Empty",
+                   baseSound: Sound.empty(.base),
+                   melodySound: Sound.empty(.melody),
+                   whiteNoiseSound: Sound.empty(.whiteNoise),
+                   fileName: "")
+    }
 }
 
 extension MixedSound {
@@ -55,9 +63,5 @@ extension MixedSound {
     }
 }
 
-let emptyMixedSound = MixedSound(name: "empty",
-                                 baseSound: Sound.empty(.base),
-                                 melodySound: Sound.empty(.melody),
-                                 whiteNoiseSound: Sound.empty(.whiteNoise),
-                                 fileName: "")
+
 

--- a/RelaxOn/Model/Sound.swift
+++ b/RelaxOn/Model/Sound.swift
@@ -14,29 +14,16 @@ struct Sound: Identifiable, Codable {
     var audioVolume: Float
     let fileName: String
     
-    static let empty: (Int, SoundType) -> Sound = {
-        return Sound(id: $0 * 10,
-                     name: "Empty",
-                     soundType: $1,
-                     audioVolume: 0.5,
-                     fileName: "")
+    static let empty: (SoundType) -> Sound = { type in
+        Sound(id: 0,
+              name: "Empty",
+              soundType: type,
+              audioVolume: 0.5,
+              fileName: "")
     }
 }
 
-var baseSound: Sound = Sound(id: 0,
-                             name: "Empty",
-                             soundType: .base,
-                             audioVolume: 0.0,
-                             fileName: "")
-var melodySound: Sound = Sound(id: 3,
-                               name: "Empty",
-                               soundType: .base,
-                               audioVolume: 0.0,
-                               fileName: "")
-var whiteNoiseSound: Sound = Sound(id: 6,
-                                name: "Empty",
-                                soundType: .base,
-                                audioVolume: 0.0,
-                                fileName: "")
+var baseSound: Sound = Sound.empty(.base)
+var melodySound: Sound = Sound.empty(.melody)
+var whiteNoiseSound: Sound = Sound.empty(.whiteNoise)
 
-var mixedAudioSources: [Sound] = []

--- a/RelaxOn/Model/SoundType.swift
+++ b/RelaxOn/Model/SoundType.swift
@@ -12,32 +12,17 @@ enum SoundType: String, CaseIterable, Codable {
     case melody
     case whiteNoise
     
-    var soundList: [Sound] {
-        var soundList = [Sound.empty(self.index, self)]
-        switch self {
-        case .base:
-            soundList.append(contentsOf: BaseSound.soundList)
-        case .melody:
-            soundList.append(contentsOf: MelodySound.soundList)
-        case .whiteNoise:
-            soundList.append(contentsOf: WhiteNoiseSound.soundList)
-        }
-        return soundList
-    }
-    
-    var index: Int {
-        switch self {
-        case .base:
-            return 0
-        case .melody:
-            return 1
-        case .whiteNoise:
-            return 2
+    static let soundList: (SoundType) -> [Sound] = { type in
+        switch type {
+        case .base: return BaseSound.soundList
+        case .melody: return MelodySound.soundList
+        case .whiteNoise: return WhiteNoiseSound.soundList
         }
     }
 }
 
 enum BaseSound: String, CaseIterable {
+    case empty
     case longSun
     case spaceMid
     case spaceLow
@@ -53,9 +38,8 @@ enum BaseSound: String, CaseIterable {
     }
     
     static var soundList: [Sound] {
-        
         return self.allCases.enumerated().map {
-            Sound(id: $0.offset + 1,
+            Sound(id: $0.offset,
                   name: $0.element.displayName,
                   soundType: .base,
                   audioVolume: 0.5,
@@ -65,6 +49,7 @@ enum BaseSound: String, CaseIterable {
 }
 
 enum MelodySound: String, CaseIterable {
+    case empty
     case ambient
     case garden
     case gymnopedie
@@ -81,7 +66,7 @@ enum MelodySound: String, CaseIterable {
     
     static var soundList: [Sound] {
         return self.allCases.enumerated().map {
-            Sound(id: $0.offset + 1 + 10,
+            Sound(id: $0.offset,
                   name: $0.element.displayName,
                   soundType: .melody,
                   audioVolume: 0.5,
@@ -91,6 +76,7 @@ enum MelodySound: String, CaseIterable {
 }
 
 enum WhiteNoiseSound: String, CaseIterable {
+    case empty
     case dryGrass
     case stream
     case summerField
@@ -107,7 +93,7 @@ enum WhiteNoiseSound: String, CaseIterable {
     
     static var soundList: [Sound] {
         return self.allCases.enumerated().map {
-            Sound(id: $0.offset + 1 + 20,
+            Sound(id: $0.offset,
                   name: $0.element.displayName,
                   soundType: .whiteNoise,
                   audioVolume: 0.5,

--- a/RelaxOn/Model/SoundType.swift
+++ b/RelaxOn/Model/SoundType.swift
@@ -43,7 +43,7 @@ enum BaseSound: String, CaseIterable {
                   name: $0.element.displayName,
                   soundType: .base,
                   audioVolume: 0.5,
-                  fileName: $0.element.fileName)
+                  fileName: $0.offset == 0 ? "" : $0.element.fileName)
         }
     }
 }
@@ -70,7 +70,7 @@ enum MelodySound: String, CaseIterable {
                   name: $0.element.displayName,
                   soundType: .melody,
                   audioVolume: 0.5,
-                  fileName: $0.element.fileName)
+                  fileName: $0.offset == 0 ? "" : $0.element.fileName)
         }
     }
 }
@@ -97,7 +97,7 @@ enum WhiteNoiseSound: String, CaseIterable {
                   name: $0.element.displayName,
                   soundType: .whiteNoise,
                   audioVolume: 0.5,
-                  fileName: $0.element.fileName)
+                  fileName: $0.offset == 0 ? "" : $0.element.fileName)
         }
     }
 }

--- a/RelaxOn/Views/Home/Music/Component/MusicController.swift
+++ b/RelaxOn/Views/Home/Music/Component/MusicController.swift
@@ -14,7 +14,7 @@ struct MusicController: View {
     var body: some View {
         HStack(spacing: hstackSpacing) {
             Button {
-                viewModel.setupPreviousTrack(mixedSound: viewModel.mixedSound ?? emptyMixedSound)
+                viewModel.setupPreviousTrack(mixedSound: viewModel.mixedSound ?? MixedSound.empty)
             } label: {
                 Image(systemName: "backward.fill")
                     .resizable()
@@ -32,7 +32,7 @@ struct MusicController: View {
             }.disabled(viewModel.mixedSound == nil)
 
             Button {
-                viewModel.setupNextTrack(mixedSound: viewModel.mixedSound ?? emptyMixedSound)
+                viewModel.setupNextTrack(mixedSound: viewModel.mixedSound ?? MixedSound.empty)
             } label: {
                 Image(systemName: "forward.fill")
                     .resizable()

--- a/RelaxOn/Views/Kitchen/CDCoverImageView.swift
+++ b/RelaxOn/Views/Kitchen/CDCoverImageView.swift
@@ -53,7 +53,7 @@ extension CDCoverImageView {
     
     @ViewBuilder
     func IllustImage(imageName: String) -> some View {
-        if imageName == "Empty" {
+        if imageName.isEmpty {
             Rectangle()
                 .fill(.clear)
         } else {

--- a/RelaxOn/Views/Kitchen/CDCoverImageView.swift
+++ b/RelaxOn/Views/Kitchen/CDCoverImageView.swift
@@ -53,7 +53,7 @@ extension CDCoverImageView {
     
     @ViewBuilder
     func IllustImage(imageName: String) -> some View {
-        if imageName.isEmpty {
+        if imageName == "Empty" {
             Rectangle()
                 .fill(.clear)
         } else {

--- a/RelaxOn/Views/Kitchen/RadioButtonGroupView.swift
+++ b/RelaxOn/Views/Kitchen/RadioButtonGroupView.swift
@@ -18,7 +18,7 @@ struct RadioButtonGroupView: View {
     var body: some View {
         LazyVGrid(columns: columns) {
             ForEach(items) { item in
-                SoundCardView(soundFileName : item.name,
+                SoundCardView(soundFileName: item.name,
                           data: item,
                           callback: radioGroupCallback,
                           selectedID: selectedId)

--- a/RelaxOn/Views/Kitchen/SoundCardView.swift
+++ b/RelaxOn/Views/Kitchen/SoundCardView.swift
@@ -34,7 +34,7 @@ struct SoundCardView: View {
         ZStack {
             VStack(alignment: .center, spacing: 10) {
                 Group {
-                    if data.name == "Empty" {
+                    if data.fileName.isEmpty {
                         Rectangle()
                             .fill(.white)
                     } else {

--- a/RelaxOn/Views/Kitchen/SoundCardView.swift
+++ b/RelaxOn/Views/Kitchen/SoundCardView.swift
@@ -29,31 +29,26 @@ struct SoundCardView: View {
         self.callback = callback
         self.selectedID = selectedID
     }
-
+    
     var body: some View {
         ZStack {
             VStack(alignment: .center, spacing: 10) {
-                if data.name == "Empty" {
-                    ZStack {
+                Group {
+                    if data.name == "Empty" {
                         Rectangle()
-                            .frame(width: (DeviceFrame.exceptPaddingWidth - 20 ) / 3 ,
-                                   height: (DeviceFrame.exceptPaddingWidth - 20 ) / 3,
-                                   alignment: .center)
-                            .border(selectedID == soundFileName ? .white : .clear, width: 2)
-                            .cornerRadius(4)
-                            .clipped()
+                            .fill(.white)
+                    } else {
+                        Image(data.fileName)
+                            .resizable()
                     }
-                } else {
-                    Image(data.fileName)
-                        .resizable()
-                        .frame(width: (DeviceFrame.exceptPaddingWidth - 20 ) / 3,
-                               height: (DeviceFrame.exceptPaddingWidth - 20 ) / 3,
-                               alignment: .center)
-                        .border(selectedID == soundFileName ? .white : .clear, width: 2)
-                        .cornerRadius(4)
-                        .clipped()
                 }
-
+                .frame(width: (DeviceFrame.exceptPaddingWidth - 20 ) / 3,
+                       height: (DeviceFrame.exceptPaddingWidth - 20 ) / 3,
+                       alignment: .center)
+                .border(selectedID == soundFileName ? .white : .clear, width: 2)
+                .cornerRadius(4)
+                .clipped()
+                
                 HStack {
                     Text(LocalizedStringKey(data.name))
                         .fontWeight(.semibold)
@@ -75,12 +70,9 @@ struct SoundCardView: View {
 struct SoundCard_Previews: PreviewProvider {
     static var previews: some View {
         SoundCardView(soundFileName : "base_default",
-                      data: SoundType.base.soundList.first ?? Sound.empty(0, .base),
-                  callback: {_,_  in },
-                  selectedID: "")
+                      data: SoundType.soundList(.base).first ?? Sound.empty(.base),
+                      callback: {_, _  in },
+                      selectedID: "")
         .background(Color.backgroundColor)
     }
 }
-
-
-

--- a/RelaxOn/Views/Kitchen/StudioView.swift
+++ b/RelaxOn/Views/Kitchen/StudioView.swift
@@ -146,7 +146,7 @@ extension StudioView {
                             selectedBaseSound = baseSelected
                             // play music
                             
-                            if selectedBaseSound.name == "Empty" {
+                            if selectedBaseSound.fileName.isEmpty {
                                 baseAudioManager.stop()
                                 
                                 opacityAnimationValues[0] = 0.0
@@ -161,7 +161,7 @@ extension StudioView {
                                              items: SoundType.soundList(.melody)) { melodySounds in
                             selectedMelodySound = melodySounds
                             
-                            if selectedMelodySound.name == "Empty" {
+                            if selectedMelodySound.fileName.isEmpty {
                                 melodyAudioManager.stop()
                                 
                                 opacityAnimationValues[1] = 0.0
@@ -176,7 +176,7 @@ extension StudioView {
                                              items: SoundType.soundList(.whiteNoise)) { whiteNoiseSounds in
                             selectedWhiteNoiseSound = whiteNoiseSounds
                             
-                            if selectedWhiteNoiseSound.name == "Empty" {
+                            if selectedWhiteNoiseSound.fileName.isEmpty {
                                 whiteNoiseAudioManager.stop()
                                 
                                 opacityAnimationValues[2] = 0.0

--- a/RelaxOn/Views/Kitchen/StudioView.swift
+++ b/RelaxOn/Views/Kitchen/StudioView.swift
@@ -142,7 +142,7 @@ extension StudioView {
                     switch soundType {
                     case .base:
                         RadioButtonGroupView(selectedId: soundType.rawValue,
-                                             items: SoundType.base.soundList) { baseSelected in
+                                             items: SoundType.soundList(.base)) { baseSelected in
                             selectedBaseSound = baseSelected
                             // play music
                             
@@ -158,7 +158,7 @@ extension StudioView {
                         }
                     case .melody:
                         RadioButtonGroupView(selectedId: soundType.rawValue,
-                                             items: SoundType.melody.soundList) { melodySounds in
+                                             items: SoundType.soundList(.melody)) { melodySounds in
                             selectedMelodySound = melodySounds
                             
                             if selectedMelodySound.name == "Empty" {
@@ -173,7 +173,7 @@ extension StudioView {
                         }
                     case .whiteNoise:
                         RadioButtonGroupView(selectedId: soundType.rawValue,
-                                             items: SoundType.whiteNoise.soundList) { whiteNoiseSounds in
+                                             items: SoundType.soundList(.whiteNoise)) { whiteNoiseSounds in
                             selectedWhiteNoiseSound = whiteNoiseSounds
                             
                             if selectedWhiteNoiseSound.name == "Empty" {
@@ -257,7 +257,7 @@ extension StudioView {
         } label: {
             Text("Mix")
                 .font(.system(size: 24, weight: .regular))
-                .foregroundColor( ($selectedBaseSound.id == 0 && $selectedMelodySound.id == 10 && $selectedWhiteNoiseSound.id == 20) ? Color.gray : Color.relaxDimPurple )
+                .foregroundColor( ($selectedBaseSound.id == 0 && $selectedMelodySound.id == 0 && $selectedWhiteNoiseSound.id == 0) ? Color.gray : Color.relaxDimPurple )
                 .onTapGesture {
                     baseSound = selectedBaseSound
                     melodySound = selectedMelodySound
@@ -275,7 +275,7 @@ extension StudioView {
                     navigateActive = true
                 }
         }
-        .disabled(($selectedBaseSound.id == 0 && $selectedMelodySound.id == 10 && $selectedWhiteNoiseSound.id == 20) ? true : false)
+        .disabled(($selectedBaseSound.id == 0 && $selectedMelodySound.id == 0 && $selectedWhiteNoiseSound.id == 0) ? true : false)
     }
 }
 
@@ -338,9 +338,9 @@ extension StudioView {
     } label: {
             Text("Mix")
                 .font(.system(size: 24, weight: .regular))
-                .foregroundColor( ($selectedBaseSound.id == 0 || $selectedMelodySound.id == 10 || $selectedWhiteNoiseSound.id == 20) ? Color.gray : Color.relaxDimPurple )
+                .foregroundColor( ($selectedBaseSound.id == 0 || $selectedMelodySound.id == 0 || $selectedWhiteNoiseSound.id == 0) ? Color.gray : Color.relaxDimPurple )
         }
-        .opacity(($selectedBaseSound.id == 0 || $selectedMelodySound.id == 10 || $selectedWhiteNoiseSound.id == 20) ? 0 : 1)
+        .opacity(($selectedBaseSound.id == 0 || $selectedMelodySound.id == 0 || $selectedWhiteNoiseSound.id == 0) ? 0 : 1)
         .simultaneousGesture(TapGesture().onEnded { _ in
             baseSound = selectedBaseSound
             melodySound = selectedMelodySound


### PR DESCRIPTION
## 작업 내용 (Content)
- Sound의 ID가 Type에 따라 0~9, 10~19, 20~29의 범위 내에서 사용되도록 되어있었습니다.
    해당 ID는 StudioView에서 ForEach에 사용될 ID를 위해 Sound에 `Identifiable`를 채택하면서 생긴 id 였고, 로직상 Type 끼리 ID의 충돌이 없는 상황이었습니다. 즉 각각의 Sound Type이 0부터 ID를 가져도 되는 상황이었습니다.
    → 각 Type마다 Sound 요소들의 ID가 0부터 [시작](https://github.com/M1zz/RelaxOn/pull/344/files#diff-a86337be06c289a0d5e295b8478833a81af84c95e7c99fffeb36e11b52bbc1b9R42)되도록 수정하였습니다. 

- ID가 수정됨에 따라 Empty Sound에 대한 정의를 수정해야했습니다.
    → 각 Type의 enum에 empty case를 넣어 Empty Sound가 ID 0을 가지도록 [수정](https://github.com/M1zz/RelaxOn/pull/344/files#diff-a86337be06c289a0d5e295b8478833a81af84c95e7c99fffeb36e11b52bbc1b9R25)하였습니다.

- Empty Sound 수정의 Side Effect
    → Empty Sound가 화면에서는 Empty라는 이름을 표시하되, fileName은 빈 문자열을 [사용](https://github.com/M1zz/RelaxOn/pull/344/files#diff-a86337be06c289a0d5e295b8478833a81af84c95e7c99fffeb36e11b52bbc1b9R46)하게하여, Empty Sound를 `fileName == “Empty”` or `name == “Empty”` 형태가 아닌 `fileName.isEmpty`로 [구분](https://github.com/M1zz/RelaxOn/pull/344/files#diff-414269c62b85e55ce64f18d7f900bcd2db83aef12b84729570663415b0379843R149)할 수 있도록하였습니다.

## 기타 사항 (Etc)
- Empty Sound의 구분은 `fileName.isEmpty`가 아닌 Sound에 `var isEmpty: Bool { get }` 을 추가하고 싶었습니다.
    Empty Sound를 구분하는 로직이 Sound 타입의 데이터가 State 변수로 선언된 곳에서, Binding 형태로 전달되면서 구분되고 있었는데([예시](https://github.com/M1zz/RelaxOn/pull/344/files#diff-414269c62b85e55ce64f18d7f900bcd2db83aef12b84729570663415b0379843R343)), 해당형태로 사용될 경우, get-only 프로퍼티를 사용하지 못하여 구현하지 못했습니다. 추후 좋은 아이디어가 생각나면 수정하거나, 생각나시는 분은 공유해주시면 감사하겠습니다.

## Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
#336 
