### PR TITLE
[BIBI] Navigation Stack 을 이용한 화면 전환 & Rename

### DIFF
--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -45,9 +45,9 @@
 		58DE61B2283A8E1700F25769 /* Sound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DE61B1283A8E1700F25769 /* Sound.swift */; };
 		58DE61C22841C20A00F25769 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 58DE61C12841C20A00F25769 /* Launch Screen.storyboard */; };
 		58DE61C72843100100F25769 /* VolumeControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DE61C62843100100F25769 /* VolumeControlView.swift */; };
-		8F53BD1729B77875009AE6D1 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F53BD1629B77875009AE6D1 /* MainView.swift */; };
-		8F53BD1929B77A83009AE6D1 /* SecondView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F53BD1829B77A83009AE6D1 /* SecondView.swift */; };
-		8F53BD1B29B77A92009AE6D1 /* ThirdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F53BD1A29B77A92009AE6D1 /* ThirdView.swift */; };
+		8F53BD1729B77875009AE6D1 /* SoundListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F53BD1629B77875009AE6D1 /* SoundListView.swift */; };
+		8F53BD1929B77A83009AE6D1 /* SoundSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F53BD1829B77A83009AE6D1 /* SoundSelectView.swift */; };
+		8F53BD1B29B77A92009AE6D1 /* SoundSaveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F53BD1A29B77A92009AE6D1 /* SoundSaveView.swift */; };
 		C753494E28B7489D0055F7CA /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753494D28B7489D0055F7CA /* View+Extension.swift */; };
 		C753495228B748D40055F7CA /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753495128B748D40055F7CA /* UIColor+Extension.swift */; };
 		C753495428B748E20055F7CA /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753495328B748E20055F7CA /* String+Extension.swift */; };
@@ -163,9 +163,9 @@
 		58DE61BE283E77E700F25769 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		58DE61C12841C20A00F25769 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		58DE61C62843100100F25769 /* VolumeControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeControlView.swift; sourceTree = "<group>"; };
-		8F53BD1629B77875009AE6D1 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
-		8F53BD1829B77A83009AE6D1 /* SecondView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondView.swift; sourceTree = "<group>"; };
-		8F53BD1A29B77A92009AE6D1 /* ThirdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdView.swift; sourceTree = "<group>"; };
+		8F53BD1629B77875009AE6D1 /* SoundListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundListView.swift; sourceTree = "<group>"; };
+		8F53BD1829B77A83009AE6D1 /* SoundSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSelectView.swift; sourceTree = "<group>"; };
+		8F53BD1A29B77A92009AE6D1 /* SoundSaveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSaveView.swift; sourceTree = "<group>"; };
 		C753494D28B7489D0055F7CA /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		C753494F28B748C80055F7CA /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		C753495128B748D40055F7CA /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
@@ -504,9 +504,9 @@
 		8F53BD1C29B77B55009AE6D1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				8F53BD1629B77875009AE6D1 /* MainView.swift */,
-				8F53BD1829B77A83009AE6D1 /* SecondView.swift */,
-				8F53BD1A29B77A92009AE6D1 /* ThirdView.swift */,
+				8F53BD1629B77875009AE6D1 /* SoundListView.swift */,
+				8F53BD1829B77A83009AE6D1 /* SoundSelectView.swift */,
+				8F53BD1A29B77A92009AE6D1 /* SoundSaveView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -693,7 +693,7 @@
 				C7C4C25A28C256BF0048DCBA /* Color+Extension.swift in Sources */,
 				58DE1021283DD9DD002CDB9F /* MusicViewModel.swift in Sources */,
 				58DE61852839C13900F25769 /* CdLibraryView.swift in Sources */,
-				8F53BD1B29B77A92009AE6D1 /* ThirdView.swift in Sources */,
+				8F53BD1B29B77A92009AE6D1 /* SoundSaveView.swift in Sources */,
 				C7A50DDC28D08FA000841BC6 /* MusicView.swift in Sources */,
 				58DE1032283DF6E7002CDB9F /* Static.swift in Sources */,
 				E24F21E228ABE1A100371BA4 /* MultiPreview.swift in Sources */,
@@ -710,7 +710,7 @@
 				E2BF105428914E9E00408B8C /* TimerNavigationLinkView.swift in Sources */,
 				E211ED072896D06A002843EE /* TimerManager.swift in Sources */,
 				C7FDCA8728D09396008FA749 /* WidgetManager.swift in Sources */,
-				8F53BD1929B77A83009AE6D1 /* SecondView.swift in Sources */,
+				8F53BD1929B77A83009AE6D1 /* SoundSelectView.swift in Sources */,
 				CC04E26528BDA45900509C60 /* SceneDelegate.swift in Sources */,
 				CC5AC134289D184A00FE847B /* CDWidgetEntry.swift in Sources */,
 				4AF70C4B28D1BC4300645D5D /* CDLibraryMusicController.swift in Sources */,
@@ -719,7 +719,7 @@
 				10D26716288EF4DB0056339A /* StudioView.swift in Sources */,
 				4A5769AC2866F20A007CCAE9 /* MixedSound.swift in Sources */,
 				C7C4C25828C242BB0048DCBA /* SoundType.swift in Sources */,
-				8F53BD1729B77875009AE6D1 /* MainView.swift in Sources */,
+				8F53BD1729B77875009AE6D1 /* SoundListView.swift in Sources */,
 				C753495828B75E4A0055F7CA /* RadioButtonGroupView.swift in Sources */,
 				E211ED052896D051002843EE /* MusicTimer.swift in Sources */,
 				C753494E28B7489D0055F7CA /* View+Extension.swift in Sources */,

--- a/RelaxOn/App/RelaxOnApp.swift
+++ b/RelaxOn/App/RelaxOnApp.swift
@@ -13,7 +13,7 @@ struct RelaxOnApp: App {
     
     var body: some Scene {
         WindowGroup {
-            MainView()
+            SoundListView()
         }
     }
 }

--- a/RelaxOn/App/Views/MainView.swift
+++ b/RelaxOn/App/Views/MainView.swift
@@ -7,10 +7,17 @@
 
 import SwiftUI
 
+struct FileInfo: Hashable {
+    let name: String
+}
+
 struct MainView: View {
     var body: some View {
         NavigationStack {
-            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+            NavigationLink("Water Drop", value: FileInfo(name: "Water Drop"))
+                .navigationDestination(for: FileInfo.self) { fileInfo in
+                    SecondView(fileInfo: fileInfo)
+                }
         }
     }
 }

--- a/RelaxOn/App/Views/SecondView.swift
+++ b/RelaxOn/App/Views/SecondView.swift
@@ -8,13 +8,19 @@
 import SwiftUI
 
 struct SecondView: View {
+    var fileInfo: FileInfo
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Text("\(self.fileInfo.name)")
+        NavigationLink("Selected Water Drop2", value: "10")
+            .navigationDestination(for: String.self) { value in
+                ThirdView()
+            }
     }
 }
 
 struct SecondView_Previews: PreviewProvider {
     static var previews: some View {
-        SecondView()
+        SecondView(fileInfo: FileInfo.init(name: "임시"))
     }
 }

--- a/RelaxOn/App/Views/SoundListView.swift
+++ b/RelaxOn/App/Views/SoundListView.swift
@@ -1,5 +1,5 @@
 //
-//  MainView.swift
+//  SoundListView.swift
 //  RelaxOn
 //
 //  Created by Doyeon on 2023/03/07.
@@ -11,12 +11,12 @@ struct FileInfo: Hashable {
     let name: String
 }
 
-struct MainView: View {
+struct SoundListView: View {
     var body: some View {
         NavigationStack {
             NavigationLink("Water Drop", value: FileInfo(name: "Water Drop"))
                 .navigationDestination(for: FileInfo.self) { fileInfo in
-                    SecondView(fileInfo: fileInfo)
+                    SoundSelectView(fileInfo: fileInfo)
                 }
         }
     }
@@ -24,6 +24,6 @@ struct MainView: View {
 
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
-        MainView()
+        SoundListView()
     }
 }

--- a/RelaxOn/App/Views/SoundSaveView.swift
+++ b/RelaxOn/App/Views/SoundSaveView.swift
@@ -1,5 +1,5 @@
 //
-//  ThirdView.swift
+//  SoundSaveView.swift
 //  RelaxOn
 //
 //  Created by Doyeon on 2023/03/07.
@@ -7,14 +7,14 @@
 
 import SwiftUI
 
-struct ThirdView: View {
+struct SoundSaveView: View {
     var body: some View {
-        Text("ThirdView")
+        Text("SoundSaveView")
     }
 }
 
 struct ThirdView_Previews: PreviewProvider {
     static var previews: some View {
-        ThirdView()
+        SoundSaveView()
     }
 }

--- a/RelaxOn/App/Views/SoundSelectView.swift
+++ b/RelaxOn/App/Views/SoundSelectView.swift
@@ -1,5 +1,5 @@
 //
-//  SecondView.swift
+//  SoundSelectView.swift
 //  RelaxOn
 //
 //  Created by Doyeon on 2023/03/07.
@@ -7,20 +7,20 @@
 
 import SwiftUI
 
-struct SecondView: View {
+struct SoundSelectView: View {
     var fileInfo: FileInfo
     
     var body: some View {
         Text("\(self.fileInfo.name)")
         NavigationLink("Selected Water Drop2", value: "10")
             .navigationDestination(for: String.self) { value in
-                ThirdView()
+                SoundSaveView()
             }
     }
 }
 
 struct SecondView_Previews: PreviewProvider {
     static var previews: some View {
-        SecondView(fileInfo: FileInfo.init(name: "임시"))
+        SoundSelectView(fileInfo: FileInfo.init(name: "임시"))
     }
 }

--- a/RelaxOn/App/Views/ThirdView.swift
+++ b/RelaxOn/App/Views/ThirdView.swift
@@ -8,8 +8,19 @@
 import SwiftUI
 
 struct ThirdView: View {
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack{
+            HStack{
+                Button {
+                    
+                } label: {
+                    Text("Cancel")
+                        .font(.system(size: 25))
+                }
+
+            }
+        }
     }
 }
 

--- a/RelaxOn/App/Views/ThirdView.swift
+++ b/RelaxOn/App/Views/ThirdView.swift
@@ -8,19 +8,8 @@
 import SwiftUI
 
 struct ThirdView: View {
-    
     var body: some View {
-        VStack{
-            HStack{
-                Button {
-                    
-                } label: {
-                    Text("Cancel")
-                        .font(.system(size: 25))
-                }
-
-            }
-        }
+        Text("ThirdView")
     }
 }
 

--- a/RelaxOn/RelaxOn.entitlements
+++ b/RelaxOn/RelaxOn.entitlements
@@ -3,8 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.relaxOn.widget.appGroup</string>
-	</array>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
## 작업 내용 (Content)
- MainView -> SecondView -> ThirdView로 화면 전환하는 구조를 만들었습니다.
- 식별가능한 이름으로 뷰 이름을 변경했습니다.
  - ✅ Main View →  Sound List View
  - ✅ Second View → Sound Select View
  - ✅ Third View → Sound Save View

## 기타 사항 (Etc)
- 현재는 해결되었으나 동일한 오류가 날 수 있기 때문에 기록해두는 내용
  - Second View -> Third View 화면 전환시
    첫번째와 동일한 방식으로 내비게이션 링크에 fileInfo를 담아 보냈을 때,
    Thired View가 아닌 Second View가 무한 반복 노출되는 오류가 있었습니다.
  - Second View가 Main View에서 전달받은 fileInfo를 가공하지 않은 상태에서
    Third View에 전달했기 때문에 났었던 오류로 추측하고 있으나 정확한 원인은 아직 파악하지 못했습니다.

## 관련 사진
![Simulator Screen Recording - iPhone 14 Pro - 2023-03-08 at 15 17 43](https://user-images.githubusercontent.com/108422901/223635293-b87ee5b1-bfc5-4842-b00f-9c7451abc99b.gif)

