### PR TITLE
✨[Feat]: Save & Load MixedSound

### DIFF
--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		8F53BD1929B77A83009AE6D1 /* SoundDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F53BD1829B77A83009AE6D1 /* SoundDetailView.swift */; };
 		8F53BD1B29B77A92009AE6D1 /* SoundSaveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F53BD1A29B77A92009AE6D1 /* SoundSaveView.swift */; };
 		8FF7603329CD304D002FF43B /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF7603229CD304D002FF43B /* AudioManager.swift */; };
+		8FFCCCDD29EE45B400079DCC /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFCCCDC29EE45B400079DCC /* UserDefaults+Extension.swift */; };
 		8FFDBC7029E6471E008C674B /* MixedSoundsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFDBC6F29E6471E008C674B /* MixedSoundsViewModel.swift */; };
 		C753494E28B7489D0055F7CA /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753494D28B7489D0055F7CA /* View+Extension.swift */; };
 		C753495228B748D40055F7CA /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753495128B748D40055F7CA /* UIColor+Extension.swift */; };
@@ -184,6 +185,7 @@
 		8F53BD1829B77A83009AE6D1 /* SoundDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundDetailView.swift; sourceTree = "<group>"; };
 		8F53BD1A29B77A92009AE6D1 /* SoundSaveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSaveView.swift; sourceTree = "<group>"; };
 		8FF7603229CD304D002FF43B /* AudioManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
+		8FFCCCDC29EE45B400079DCC /* UserDefaults+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extension.swift"; sourceTree = "<group>"; };
 		8FFDBC6F29E6471E008C674B /* MixedSoundsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedSoundsViewModel.swift; sourceTree = "<group>"; };
 		C753494D28B7489D0055F7CA /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		C753494F28B748C80055F7CA /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
@@ -575,6 +577,14 @@
 			path = Manager;
 			sourceTree = "<group>";
 		};
+		8FFCCCDB29EE459400079DCC /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				8FFCCCDC29EE45B400079DCC /* UserDefaults+Extension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		8FFDBC6E29E646F5008C674B /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -620,6 +630,7 @@
 				58DE61822839C13900F25769 /* RelaxOnApp.swift */,
 				CC04E26228BDA3F800509C60 /* AppDelegate.swift */,
 				CC04E26428BDA45900509C60 /* SceneDelegate.swift */,
+				8FFCCCDB29EE459400079DCC /* Extensions */,
 				8FFDBC6E29E646F5008C674B /* ViewModel */,
 				8FF7603129CD3036002FF43B /* Manager */,
 				8F4E1B6B29B9BE240013599C /* Models */,
@@ -813,6 +824,7 @@
 				CC5AC112289C033D00FE847B /* RelaxOnWidget.intentdefinition in Sources */,
 				8F4B080729D1B38C0011995F /* UserDefaultsManager.swift in Sources */,
 				10FB81B528A17468000168CC /* OnboardingFinishView.swift in Sources */,
+				8FFCCCDD29EE45B400079DCC /* UserDefaults+Extension.swift in Sources */,
 				101417FA289EB9F300F40397 /* CDNamingView.swift in Sources */,
 				21D897782892D48600A20FFE /* CDCardView.swift in Sources */,
 				C753495228B748D40055F7CA /* UIColor+Extension.swift in Sources */,

--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		8F0FC49B29C1DD5D00F923A5 /* OldAudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0FC49829C1DD5D00F923A5 /* OldAudioManager.swift */; };
 		8F0FC49C29C1DD5D00F923A5 /* OldTimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0FC49929C1DD5D00F923A5 /* OldTimerManager.swift */; };
 		8F0FC49D29C1DD5D00F923A5 /* OldUserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0FC49A29C1DD5D00F923A5 /* OldUserDefaultsManager.swift */; };
+		8F4B080729D1B38C0011995F /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4B080629D1B38C0011995F /* UserDefaultsManager.swift */; };
 		8F4E1B6129B9A48F0013599C /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4E1B6029B9A48F0013599C /* MainTabView.swift */; };
 		8F4E1B6329B9A5AE0013599C /* ListenListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4E1B6229B9A5AE0013599C /* ListenListView.swift */; };
 		8F4E1B6529B9A67E0013599C /* RelaxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4E1B6429B9A67E0013599C /* RelaxView.swift */; };
@@ -172,6 +173,7 @@
 		8F0FC49829C1DD5D00F923A5 /* OldAudioManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldAudioManager.swift; sourceTree = "<group>"; };
 		8F0FC49929C1DD5D00F923A5 /* OldTimerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldTimerManager.swift; sourceTree = "<group>"; };
 		8F0FC49A29C1DD5D00F923A5 /* OldUserDefaultsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldUserDefaultsManager.swift; sourceTree = "<group>"; };
+		8F4B080629D1B38C0011995F /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		8F4E1B6029B9A48F0013599C /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		8F4E1B6229B9A5AE0013599C /* ListenListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenListView.swift; sourceTree = "<group>"; };
 		8F4E1B6429B9A67E0013599C /* RelaxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaxView.swift; sourceTree = "<group>"; };
@@ -563,6 +565,7 @@
 			isa = PBXGroup;
 			children = (
 				8FF7603229CD304D002FF43B /* AudioManager.swift */,
+				8F4B080629D1B38C0011995F /* UserDefaultsManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -793,6 +796,7 @@
 				E2BF105B28917CAC00408B8C /* TimerSettingView.swift in Sources */,
 				8F0FC49C29C1DD5D00F923A5 /* OldTimerManager.swift in Sources */,
 				CC5AC112289C033D00FE847B /* RelaxOnWidget.intentdefinition in Sources */,
+				8F4B080729D1B38C0011995F /* UserDefaultsManager.swift in Sources */,
 				10FB81B528A17468000168CC /* OnboardingFinishView.swift in Sources */,
 				101417FA289EB9F300F40397 /* CDNamingView.swift in Sources */,
 				21D897782892D48600A20FFE /* CDCardView.swift in Sources */,

--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		8F0FC49B29C1DD5D00F923A5 /* OldAudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0FC49829C1DD5D00F923A5 /* OldAudioManager.swift */; };
 		8F0FC49C29C1DD5D00F923A5 /* OldTimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0FC49929C1DD5D00F923A5 /* OldTimerManager.swift */; };
 		8F0FC49D29C1DD5D00F923A5 /* OldUserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0FC49A29C1DD5D00F923A5 /* OldUserDefaultsManager.swift */; };
+		8F31407D29D428B900BB5410 /* UserFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F31407C29D428B900BB5410 /* UserFileManager.swift */; };
 		8F4B080729D1B38C0011995F /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4B080629D1B38C0011995F /* UserDefaultsManager.swift */; };
 		8F4E1B6129B9A48F0013599C /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4E1B6029B9A48F0013599C /* MainTabView.swift */; };
 		8F4E1B6329B9A5AE0013599C /* ListenListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4E1B6229B9A5AE0013599C /* ListenListView.swift */; };
@@ -173,6 +174,7 @@
 		8F0FC49829C1DD5D00F923A5 /* OldAudioManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldAudioManager.swift; sourceTree = "<group>"; };
 		8F0FC49929C1DD5D00F923A5 /* OldTimerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldTimerManager.swift; sourceTree = "<group>"; };
 		8F0FC49A29C1DD5D00F923A5 /* OldUserDefaultsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldUserDefaultsManager.swift; sourceTree = "<group>"; };
+		8F31407C29D428B900BB5410 /* UserFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFileManager.swift; sourceTree = "<group>"; };
 		8F4B080629D1B38C0011995F /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		8F4E1B6029B9A48F0013599C /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		8F4E1B6229B9A5AE0013599C /* ListenListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenListView.swift; sourceTree = "<group>"; };
@@ -566,6 +568,7 @@
 			children = (
 				8FF7603229CD304D002FF43B /* AudioManager.swift */,
 				8F4B080629D1B38C0011995F /* UserDefaultsManager.swift */,
+				8F31407C29D428B900BB5410 /* UserFileManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -765,6 +768,7 @@
 				C753495628B75BD20055F7CA /* Float+Extension.swift in Sources */,
 				219BD67328900A28006FAF55 /* CDListView.swift in Sources */,
 				E206D1A428D2B97500DDB4E7 /* TimerProgressBarView.swift in Sources */,
+				8F31407D29D428B900BB5410 /* UserFileManager.swift in Sources */,
 				8F0FC49B29C1DD5D00F923A5 /* OldAudioManager.swift in Sources */,
 				CBFDC8F4289C23AC00386FB5 /* VolumeSlider.swift in Sources */,
 				58DE61B2283A8E1700F25769 /* OldSound.swift in Sources */,

--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		8F53BD1929B77A83009AE6D1 /* SoundDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F53BD1829B77A83009AE6D1 /* SoundDetailView.swift */; };
 		8F53BD1B29B77A92009AE6D1 /* SoundSaveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F53BD1A29B77A92009AE6D1 /* SoundSaveView.swift */; };
 		8FF7603329CD304D002FF43B /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF7603229CD304D002FF43B /* AudioManager.swift */; };
+		8FFDBC7029E6471E008C674B /* MixedSoundsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFDBC6F29E6471E008C674B /* MixedSoundsViewModel.swift */; };
 		C753494E28B7489D0055F7CA /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753494D28B7489D0055F7CA /* View+Extension.swift */; };
 		C753495228B748D40055F7CA /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753495128B748D40055F7CA /* UIColor+Extension.swift */; };
 		C753495428B748E20055F7CA /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753495328B748E20055F7CA /* String+Extension.swift */; };
@@ -183,6 +184,7 @@
 		8F53BD1829B77A83009AE6D1 /* SoundDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundDetailView.swift; sourceTree = "<group>"; };
 		8F53BD1A29B77A92009AE6D1 /* SoundSaveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSaveView.swift; sourceTree = "<group>"; };
 		8FF7603229CD304D002FF43B /* AudioManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
+		8FFDBC6F29E6471E008C674B /* MixedSoundsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedSoundsViewModel.swift; sourceTree = "<group>"; };
 		C753494D28B7489D0055F7CA /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		C753494F28B748C80055F7CA /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		C753495128B748D40055F7CA /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
@@ -573,6 +575,14 @@
 			path = Manager;
 			sourceTree = "<group>";
 		};
+		8FFDBC6E29E646F5008C674B /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				8FFDBC6F29E6471E008C674B /* MixedSoundsViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		C753494C28B748710055F7CA /* Extension */ = {
 			isa = PBXGroup;
 			children = (
@@ -610,6 +620,7 @@
 				58DE61822839C13900F25769 /* RelaxOnApp.swift */,
 				CC04E26228BDA3F800509C60 /* AppDelegate.swift */,
 				CC04E26428BDA45900509C60 /* SceneDelegate.swift */,
+				8FFDBC6E29E646F5008C674B /* ViewModel */,
 				8FF7603129CD3036002FF43B /* Manager */,
 				8F4E1B6B29B9BE240013599C /* Models */,
 				C7C4C25528C239FE0048DCBA /* Assets */,
@@ -805,6 +816,7 @@
 				101417FA289EB9F300F40397 /* CDNamingView.swift in Sources */,
 				21D897782892D48600A20FFE /* CDCardView.swift in Sources */,
 				C753495228B748D40055F7CA /* UIColor+Extension.swift in Sources */,
+				8FFDBC7029E6471E008C674B /* MixedSoundsViewModel.swift in Sources */,
 				C753495428B748E20055F7CA /* String+Extension.swift in Sources */,
 				2193316028D2B1A5006D1E75 /* VolumeSliderView.swift in Sources */,
 				8F4E1B6529B9A67E0013599C /* RelaxView.swift in Sources */,

--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		8F53BD1B29B77A92009AE6D1 /* SoundSaveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F53BD1A29B77A92009AE6D1 /* SoundSaveView.swift */; };
 		8FF7603329CD304D002FF43B /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF7603229CD304D002FF43B /* AudioManager.swift */; };
 		8FFCCCDD29EE45B400079DCC /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFCCCDC29EE45B400079DCC /* UserDefaults+Extension.swift */; };
+		8FFCCCDF29EE55DD00079DCC /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFCCCDE29EE55DD00079DCC /* AppState.swift */; };
 		8FFDBC7029E6471E008C674B /* MixedSoundsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFDBC6F29E6471E008C674B /* MixedSoundsViewModel.swift */; };
 		C753494E28B7489D0055F7CA /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753494D28B7489D0055F7CA /* View+Extension.swift */; };
 		C753495228B748D40055F7CA /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753495128B748D40055F7CA /* UIColor+Extension.swift */; };
@@ -186,6 +187,7 @@
 		8F53BD1A29B77A92009AE6D1 /* SoundSaveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSaveView.swift; sourceTree = "<group>"; };
 		8FF7603229CD304D002FF43B /* AudioManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
 		8FFCCCDC29EE45B400079DCC /* UserDefaults+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extension.swift"; sourceTree = "<group>"; };
+		8FFCCCDE29EE55DD00079DCC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		8FFDBC6F29E6471E008C674B /* MixedSoundsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedSoundsViewModel.swift; sourceTree = "<group>"; };
 		C753494D28B7489D0055F7CA /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		C753494F28B748C80055F7CA /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
@@ -589,6 +591,7 @@
 			isa = PBXGroup;
 			children = (
 				8FFDBC6F29E6471E008C674B /* MixedSoundsViewModel.swift */,
+				8FFCCCDE29EE55DD00079DCC /* AppState.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -800,6 +803,7 @@
 				E206D1A828D3AD3400DDB4E7 /* CustomNavigationLink.swift in Sources */,
 				E2BF105428914E9E00408B8C /* TimerNavigationLinkView.swift in Sources */,
 				C7FDCA8728D09396008FA749 /* WidgetManager.swift in Sources */,
+				8FFCCCDF29EE55DD00079DCC /* AppState.swift in Sources */,
 				8F53BD1929B77A83009AE6D1 /* SoundDetailView.swift in Sources */,
 				CC04E26528BDA45900509C60 /* SceneDelegate.swift in Sources */,
 				CC5AC134289D184A00FE847B /* CDWidgetEntry.swift in Sources */,

--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		8FF7603329CD304D002FF43B /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF7603229CD304D002FF43B /* AudioManager.swift */; };
 		8FFCCCDD29EE45B400079DCC /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFCCCDC29EE45B400079DCC /* UserDefaults+Extension.swift */; };
 		8FFCCCDF29EE55DD00079DCC /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFCCCDE29EE55DD00079DCC /* AppState.swift */; };
+		8FFCCCE429EE686B00079DCC /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFCCCE329EE686B00079DCC /* Errors.swift */; };
 		8FFDBC7029E6471E008C674B /* MixedSoundsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFDBC6F29E6471E008C674B /* MixedSoundsViewModel.swift */; };
 		C753494E28B7489D0055F7CA /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753494D28B7489D0055F7CA /* View+Extension.swift */; };
 		C753495228B748D40055F7CA /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753495128B748D40055F7CA /* UIColor+Extension.swift */; };
@@ -188,6 +189,7 @@
 		8FF7603229CD304D002FF43B /* AudioManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
 		8FFCCCDC29EE45B400079DCC /* UserDefaults+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extension.swift"; sourceTree = "<group>"; };
 		8FFCCCDE29EE55DD00079DCC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		8FFCCCE329EE686B00079DCC /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		8FFDBC6F29E6471E008C674B /* MixedSoundsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedSoundsViewModel.swift; sourceTree = "<group>"; };
 		C753494D28B7489D0055F7CA /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		C753494F28B748C80055F7CA /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
@@ -587,6 +589,14 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		8FFCCCE229EE685D00079DCC /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				8FFCCCE329EE686B00079DCC /* Errors.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		8FFDBC6E29E646F5008C674B /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -630,6 +640,7 @@
 		C7C4C25628C23A3B0048DCBA /* App */ = {
 			isa = PBXGroup;
 			children = (
+				8FFCCCE229EE685D00079DCC /* Utils */,
 				58DE61822839C13900F25769 /* RelaxOnApp.swift */,
 				CC04E26228BDA3F800509C60 /* AppDelegate.swift */,
 				CC04E26428BDA45900509C60 /* SceneDelegate.swift */,
@@ -801,6 +812,7 @@
 				101417F8289EB82200F40397 /* CDCoverImageView.swift in Sources */,
 				58DE61C72843100100F25769 /* VolumeControlView.swift in Sources */,
 				E206D1A828D3AD3400DDB4E7 /* CustomNavigationLink.swift in Sources */,
+				8FFCCCE429EE686B00079DCC /* Errors.swift in Sources */,
 				E2BF105428914E9E00408B8C /* TimerNavigationLinkView.swift in Sources */,
 				C7FDCA8728D09396008FA749 /* WidgetManager.swift in Sources */,
 				8FFCCCDF29EE55DD00079DCC /* AppState.swift in Sources */,

--- a/RelaxOn/App/Extensions/UserDefaults+Extension.swift
+++ b/RelaxOn/App/Extensions/UserDefaults+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  UserDefaults+Extension.swift
+//  RelaxOn
+//
+//  Created by Doyeon on 2023/04/18.
+//
+
+import Foundation
+
+extension UserDefaults {
+    struct Keys {
+        static let mixedSound = "mixedSound"
+    }
+}

--- a/RelaxOn/App/Manager/AudioManager.swift
+++ b/RelaxOn/App/Manager/AudioManager.swift
@@ -34,13 +34,13 @@ final class AudioManager: ObservableObject {
         )
     }
     
-    /// MixedSound타입의 객체를 반복 재생
-    func playAudio(mixedSound: MixedSound) {
-        if let url = getPathUrl(forResource: mixedSound.fileName, musicExtension: .mp3) {
+    /// Sound타입의 객체를 반복 재생
+    func playAudio(sound: Sound) {
+        if let url = getPathUrl(forResource: sound.name, musicExtension: .mp3) {
             do {
                 audioPlayer = try AVAudioPlayer(contentsOf: url) // url 기반으로 음원 재생이 가능한 플레이어 객체를 생성, 오류가 발생하면 catch 블록으로 이동한다.
                 audioPlayer?.prepareToPlay() // 오디오 파일을 메모리에 로드
-                audioPlayer?.volume = mixedSound.volume // 플레이어의 볼륨을 전달 받은 mixedSound의 볼륨값으로 설정
+                audioPlayer?.volume = sound.volume // 플레이어의 볼륨을 전달 받은 mixedSound의 볼륨값으로 설정
                 audioPlayer?.numberOfLoops = -1 // 오디오 파일이 무한 루프로 반복되는 횟수를 설정 (-1: 무한반복, 0: 반복안함, 1: 1번만 반복)
                 audioPlayer?.play()
             } catch {

--- a/RelaxOn/App/Manager/AudioManager.swift
+++ b/RelaxOn/App/Manager/AudioManager.swift
@@ -52,5 +52,22 @@ final class AudioManager: ObservableObject {
         audioPlayer?.stop()
         audioPlayer?.currentTime = 0 // currentTime을 0으로 설정하지 않으면 오디오 플레이어가 중지된 지점부터 play()됨
     }
+    
+    func playMixedSound(_ mixedSound: MixedSound) {
+        guard let fileURL = URL(string: mixedSound.audioFileURL) else {
+            print("파일의 URL을 가져올 수 없습니다.")
+            return
+        }
+        
+        do {
+            audioPlayer = try AVAudioPlayer(contentsOf: fileURL)
+            audioPlayer?.prepareToPlay()
+            audioPlayer?.volume = mixedSound.volume
+            audioPlayer?.numberOfLoops = -1
+            audioPlayer?.play()
+        } catch {
+            print("Audio playback error: \(error.localizedDescription)")
+        }
+    }
 
 }

--- a/RelaxOn/App/Manager/AudioManager.swift
+++ b/RelaxOn/App/Manager/AudioManager.swift
@@ -13,7 +13,6 @@ final class AudioManager: ObservableObject {
     @Published var audioPlayer: AVAudioPlayer?
     @Published var volume: Float = 0.5
     
-    
     private enum MusicExtension: String {
         case mp3
     }

--- a/RelaxOn/App/Manager/UserDefaultsManager.swift
+++ b/RelaxOn/App/Manager/UserDefaultsManager.swift
@@ -13,7 +13,7 @@ final class UserDefaultsManager {
     private let MIXED_SOUND_KEY = "mixedSound"
 }
 
-/// Data Get, Set Properties
+// MARK: - Data Get, Set Properties
 extension UserDefaultsManager {
     var mixedSound: Data? {
         get {

--- a/RelaxOn/App/Manager/UserDefaultsManager.swift
+++ b/RelaxOn/App/Manager/UserDefaultsManager.swift
@@ -15,13 +15,32 @@ final class UserDefaultsManager {
 
 // MARK: - Data Get, Set Properties
 extension UserDefaultsManager {
-    var mixedSound: Data? {
+
+    /// 유저가 저장한 MixedSounds 의 정보를 UserDefaults에 저장하기 위한 프로퍼티
+    private var mixedSounds: [MixedSound] {
         get {
-            return standard.data(forKey: MIXED_SOUND_KEY)
+            /// mixedSounds 조회시 저장된 데이터가 없다면 빈 배열 전달
+            guard let data = standard.data(forKey: MIXED_SOUND_KEY) else { return [] }
+            /// 파일이 존재한다면 JSONDecoder를 이용하여 디코딩하여 전달
+            let decoder = JSONDecoder()
+            /// 디코딩에 실패하면 빈 배열 전달
+            return (try? decoder.decode([MixedSound].self, from: data)) ?? []
         }
         
         set {
-            standard.set(newValue, forKey: MIXED_SOUND_KEY)
+            /// mixedSounds 저장할 때 JSONEncoder를 이용하여 인코딩 후 저장
+            let encoder = JSONEncoder()
+            if let encodedData = try? encoder.encode(newValue) {
+                /// 인코딩에 성공하면 MIXED_SOUND_KEY 값으로 데이터 저장
+                standard.set(encodedData, forKey: MIXED_SOUND_KEY)
+            }
         }
+    }
+    
+    private func removeMixedSound(_ mixedSound: MixedSound) {
+        var mixedSoundArray = mixedSounds
+        /// 전달 받은 mixedSound의 id값과 동일한 mixedSound 삭제
+        mixedSoundArray.removeAll { $0.id == mixedSound.id }
+        mixedSounds = mixedSoundArray
     }
 }

--- a/RelaxOn/App/Manager/UserDefaultsManager.swift
+++ b/RelaxOn/App/Manager/UserDefaultsManager.swift
@@ -17,7 +17,7 @@ final class UserDefaultsManager {
 extension UserDefaultsManager {
 
     /// 유저가 저장한 MixedSounds 의 정보를 UserDefaults에 저장하기 위한 프로퍼티
-    private var mixedSounds: [MixedSound] {
+    var mixedSounds: [MixedSound] {
         get {
             /// mixedSounds 조회시 저장된 데이터가 없다면 빈 배열 전달
             guard let data = standard.data(forKey: MIXED_SOUND_KEY) else { return [] }

--- a/RelaxOn/App/Manager/UserDefaultsManager.swift
+++ b/RelaxOn/App/Manager/UserDefaultsManager.swift
@@ -1,0 +1,27 @@
+//
+//  UserDefaultsManager.swift
+//  RelaxOn
+//
+//  Created by Doyeon on 2023/03/27.
+//
+
+import Foundation
+
+final class UserDefaultsManager {
+    static let shared = UserDefaultsManager()
+    private let standard = UserDefaults.standard
+    private let MIXED_SOUND_KEY = "mixedSound"
+}
+
+/// Data Get, Set Properties
+extension UserDefaultsManager {
+    var mixedSound: Data? {
+        get {
+            return standard.data(forKey: MIXED_SOUND_KEY)
+        }
+        
+        set {
+            standard.set(newValue, forKey: MIXED_SOUND_KEY)
+        }
+    }
+}

--- a/RelaxOn/App/Manager/UserDefaultsManager.swift
+++ b/RelaxOn/App/Manager/UserDefaultsManager.swift
@@ -10,7 +10,7 @@ import Foundation
 final class UserDefaultsManager {
     static let shared = UserDefaultsManager()
     private let standard = UserDefaults.standard
-    private let MIXED_SOUND_KEY = "mixedSound"
+    private let MIXED_SOUND_KEY = UserDefaults.Keys.mixedSound
 }
 
 // MARK: - Data Get, Set Properties

--- a/RelaxOn/App/Manager/UserDefaultsManager.swift
+++ b/RelaxOn/App/Manager/UserDefaultsManager.swift
@@ -37,7 +37,7 @@ extension UserDefaultsManager {
         }
     }
     
-    private func removeMixedSound(_ mixedSound: MixedSound) {
+    func removeMixedSound(_ mixedSound: MixedSound) {
         var mixedSoundArray = mixedSounds
         /// 전달 받은 mixedSound의 id값과 동일한 mixedSound 삭제
         mixedSoundArray.removeAll { $0.id == mixedSound.id }

--- a/RelaxOn/App/Manager/UserFileManager.swift
+++ b/RelaxOn/App/Manager/UserFileManager.swift
@@ -1,0 +1,75 @@
+//
+//  UserFileManager.swift
+//  RelaxOn
+//
+//  Created by Doyeon on 2023/03/29.
+//
+
+import Foundation
+
+enum UserFileManagerError: Error {
+    case fileNotFound
+}
+
+final class UserFileManager {
+    static let shared = UserFileManager()
+    
+    private let fileExtension = "json"
+    private let fileManager = FileManager.default
+    private var documentsDirectory: URL {
+        return fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+    }
+    
+    private init() {}
+    
+    /// MixedSound 오브젝트를 앱의 문서 디렉터리에 JSON 파일로 저장합니다.
+    /// - Parameter mixedSound: 저장할 MixedSound 오브젝트입니다.
+    /// - Throws: 인코딩 또는 파일 쓰기에 실패한 경우 오류입니다.
+    func saveMixedSound(_ mixedSound: MixedSound) throws {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(mixedSound)
+        let fileName = "\(mixedSound.id.uuidString).\(fileExtension)"
+        let fileURL = documentsDirectory.appendingPathComponent(fileName)
+        
+        // 필요한 경우 중간 디렉터리를 생성합니다.
+        try fileManager.createDirectory(at: documentsDirectory, withIntermediateDirectories: true, attributes: nil)
+        
+        // 파일에 데이터 저장하기
+        try data.write(to: fileURL)
+    }
+    
+    /// 앱의 문서 디렉토리에서 MixedSound 오브젝트의 JSON 파일을 삭제합니다.
+    /// - Parameter mixedSound: 삭제할 MixedSound 객체입니다.
+    /// - Throws: 파일을 찾을 수 없거나 제거에 실패한 경우 오류입니다.
+    func deleteMixedSound(_ mixedSound: MixedSound) throws {
+        let fileName = "\(mixedSound.id.uuidString).\(fileExtension)"
+        let fileURL = documentsDirectory.appendingPathComponent(fileName)
+        
+        // 파일 존재 여부 확인
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            throw UserFileManagerError.fileNotFound
+        }
+        
+        // 파일 제거
+        try fileManager.removeItem(at: fileURL)
+    }
+    
+    /// 앱의 문서 디렉토리에서 모든 MixedSound 오브젝트를 로드합니다.
+    /// - Returns: MixedSound 오브젝트의 배열입니다.
+    /// - Throws: 디렉터리 읽기, 디코딩 또는 파일 로딩에 실패하면 오류가 발생합니다.
+    func loadAllMixedSounds() throws -> [MixedSound] {
+        let contents = try fileManager.contentsOfDirectory(at: documentsDirectory, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
+        let decoder = JSONDecoder()
+        var mixedSounds: [MixedSound] = []
+        
+        for fileURL in contents {
+            if fileURL.pathExtension == fileExtension {
+                let data = try Data(contentsOf: fileURL)
+                let mixedSound = try decoder.decode(MixedSound.self, from: data)
+                mixedSounds.append(mixedSound)
+            }
+        }
+        
+        return mixedSounds
+    }
+}

--- a/RelaxOn/App/Manager/UserFileManager.swift
+++ b/RelaxOn/App/Manager/UserFileManager.swift
@@ -7,10 +7,6 @@
 
 import Foundation
 
-enum UserFileManagerError: Error {
-    case fileNotFound
-}
-
 final class UserFileManager {
     static let shared = UserFileManager()
     

--- a/RelaxOn/App/Manager/UserFileManager.swift
+++ b/RelaxOn/App/Manager/UserFileManager.swift
@@ -36,6 +36,11 @@ final class UserFileManager {
         
         // 파일에 데이터 저장하기
         try data.write(to: fileURL)
+        
+        // UserDefaultsManager를 사용하여 MixedSound 정보 저장하기
+        var mixedSounds = UserDefaultsManager.shared.mixedSounds
+        mixedSounds.append(mixedSound)
+        UserDefaultsManager.shared.mixedSounds = mixedSounds
     }
     
     /// 앱의 문서 디렉토리에서 MixedSound 오브젝트의 JSON 파일을 삭제합니다.

--- a/RelaxOn/App/Manager/UserFileManager.swift
+++ b/RelaxOn/App/Manager/UserFileManager.swift
@@ -35,7 +35,11 @@ final class UserFileManager {
         try fileManager.createDirectory(at: documentsDirectory, withIntermediateDirectories: true, attributes: nil)
         
         // 파일에 데이터 저장하기
-        try data.write(to: fileURL)
+        do {
+            try data.write(to: fileURL)
+        } catch {
+            throw MixedSoundError.fileSaveFailed
+        }
         
         // UserDefaultsManager를 사용하여 MixedSound 정보 저장하기
         var mixedSounds = UserDefaultsManager.shared.mixedSounds

--- a/RelaxOn/App/Models/MixedSound.swift
+++ b/RelaxOn/App/Models/MixedSound.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct MixedSound: Hashable, Codable {
     let id: UUID            // 생성된 MixedSound의 고유 아이디
-    var fileName: String    // Original Sound의 fileName
+    var fileName: String    // 생성된 MixedSound의 fileName
     var volume: Float       // 저장할 볼륨 값
     var imageName: String   // 저장할 이미지
     

--- a/RelaxOn/App/Models/MixedSound.swift
+++ b/RelaxOn/App/Models/MixedSound.swift
@@ -13,7 +13,7 @@ struct MixedSound: Hashable, Codable {
     var volume: Float       // 저장할 볼륨 값
     var imageName: String   // 저장할 이미지
     
-    init(name: String, volume: Float = 0.5, imageName: String = "photo") {
+    init(name: String, volume: Float = 0.5, imageName: String = "placeholderImage") {
         self.id = UUID()
         self.name = name
         self.volume = volume

--- a/RelaxOn/App/Models/MixedSound.swift
+++ b/RelaxOn/App/Models/MixedSound.swift
@@ -7,16 +7,18 @@
 
 import Foundation
 
-struct MixedSound: Hashable, Codable {
-    let id: UUID            // 생성된 MixedSound의 고유 아이디
-    var name: String        // 생성된 MixedSound의 name
-    var volume: Float       // 저장할 볼륨 값
-    var imageName: String   // 저장할 이미지
+struct MixedSound: Identifiable, Codable {
+    let id: UUID             // 생성된 MixedSound의 고유 아이디
+    var name: String         // 생성된 MixedSound의 name
+    var volume: Float        // 저장할 볼륨 값
+    var imageName: String    // 저장할 이미지
+    var audioFileURL: String // 저장된 오디오 파일의 URL
     
-    init(name: String, volume: Float = 0.5, imageName: String = "placeholderImage") {
+    init(name: String, volume: Float = 0.5, imageName: String = "placeholderImage", audioFileURL: String = "") {
         self.id = UUID()
         self.name = name
         self.volume = volume
         self.imageName = imageName
+        self.audioFileURL = audioFileURL
     }
 }

--- a/RelaxOn/App/Models/MixedSound.swift
+++ b/RelaxOn/App/Models/MixedSound.swift
@@ -9,13 +9,13 @@ import Foundation
 
 struct MixedSound: Hashable, Codable {
     let id: UUID            // 생성된 MixedSound의 고유 아이디
-    var fileName: String    // 생성된 MixedSound의 fileName
+    var name: String        // 생성된 MixedSound의 name
     var volume: Float       // 저장할 볼륨 값
     var imageName: String   // 저장할 이미지
     
-    init(fileName: String, volume: Float = 0.5, imageName: String = recipeRandomName.randomElement()!) {
+    init(name: String, volume: Float = 0.5, imageName: String = "photo") {
         self.id = UUID()
-        self.fileName = fileName
+        self.name = name
         self.volume = volume
         self.imageName = imageName
     }

--- a/RelaxOn/App/Models/MixedSound.swift
+++ b/RelaxOn/App/Models/MixedSound.swift
@@ -7,7 +7,15 @@
 
 import Foundation
 
-struct MixedSound { // Hashable
-    var fileName: String
-    var volume: Float
+struct MixedSound: Hashable {
+    let id = UUID()         // 생성된 MixedSound의 고유 아이디
+    var fileName: String    // Original Sound의 fileName
+    var volume: Float       // 저장할 볼륨 값
+    var imageName: String   // 저장할 이미지
+    
+    init(fileName: String, volume: Float = 0.5, imageName: String = recipeRandomName.randomElement()!) {
+        self.fileName = fileName
+        self.volume = volume
+        self.imageName = imageName
+    }
 }

--- a/RelaxOn/App/Models/MixedSound.swift
+++ b/RelaxOn/App/Models/MixedSound.swift
@@ -1,5 +1,5 @@
 //
-//  FileInfo.swift
+//  MixedSound.swift
 //  RelaxOn
 //
 //  Created by Doyeon on 2023/03/10.
@@ -7,13 +7,14 @@
 
 import Foundation
 
-struct MixedSound: Hashable {
-    let id = UUID()         // 생성된 MixedSound의 고유 아이디
+struct MixedSound: Hashable, Codable {
+    let id: UUID            // 생성된 MixedSound의 고유 아이디
     var fileName: String    // Original Sound의 fileName
     var volume: Float       // 저장할 볼륨 값
     var imageName: String   // 저장할 이미지
     
     init(fileName: String, volume: Float = 0.5, imageName: String = recipeRandomName.randomElement()!) {
+        self.id = UUID()
         self.fileName = fileName
         self.volume = volume
         self.imageName = imageName

--- a/RelaxOn/App/Models/Sound.swift
+++ b/RelaxOn/App/Models/Sound.swift
@@ -12,7 +12,7 @@ struct Sound {
     var volume: Float
     let imageName: String
     
-    init(name: String, volume: Float = 0.5, imageName: String = "photo") {
+    init(name: String, volume: Float = 0.5, imageName: String = "placeholderImage") {
         self.name = name
         self.volume = volume
         self.imageName = imageName

--- a/RelaxOn/App/Models/Sound.swift
+++ b/RelaxOn/App/Models/Sound.swift
@@ -12,7 +12,7 @@ struct Sound {
     var volume: Float
     let imageName: String
     
-    init(name: String, volume: Float = 0.5, imageName: String = recipeRandomName.randomElement()!) {
+    init(name: String, volume: Float = 0.5, imageName: String = "photo") {
         self.name = name
         self.volume = volume
         self.imageName = imageName

--- a/RelaxOn/App/Models/Sound.swift
+++ b/RelaxOn/App/Models/Sound.swift
@@ -9,4 +9,12 @@ import Foundation
 
 struct Sound {
     let name: String
+    var volume: Float
+    let imageName: String
+    
+    init(name: String, volume: Float = 0.5, imageName: String = recipeRandomName.randomElement()!) {
+        self.name = name
+        self.volume = volume
+        self.imageName = imageName
+    }
 }

--- a/RelaxOn/App/RelaxOnApp.swift
+++ b/RelaxOn/App/RelaxOnApp.swift
@@ -7,13 +7,21 @@
 
 import SwiftUI
 
+/// 전역적인 상태를 관리하는 ViewModel
+/// SoundSaveView 에서 Modal을 dismiss 한 후 Listen 탭으로 이동하기 위해 필요
+class AppState: ObservableObject {
+    @Published var selectedTab: Int = 0
+}
+
 @main
 struct RelaxOnApp: App {
     @UIApplicationDelegateAdaptor var delegate: AppDelegate
+    @StateObject private var appState = AppState()
     
     var body: some Scene {
         WindowGroup {
             MainTabView()
+                .environmentObject(appState)
         }
     }
 }

--- a/RelaxOn/App/RelaxOnApp.swift
+++ b/RelaxOn/App/RelaxOnApp.swift
@@ -7,12 +7,6 @@
 
 import SwiftUI
 
-/// 전역적인 상태를 관리하는 ViewModel
-/// SoundSaveView 에서 Modal을 dismiss 한 후 Listen 탭으로 이동하기 위해 필요
-class AppState: ObservableObject {
-    @Published var selectedTab: Int = 0
-}
-
 @main
 struct RelaxOnApp: App {
     @UIApplicationDelegateAdaptor var delegate: AppDelegate

--- a/RelaxOn/App/Utils/Errors.swift
+++ b/RelaxOn/App/Utils/Errors.swift
@@ -1,0 +1,18 @@
+//
+//  Errors.swift
+//  RelaxOn
+//
+//  Created by Doyeon on 2023/04/18.
+//
+
+import Foundation
+
+enum UserFileManagerError: Error {
+    case fileNotFound
+}
+
+enum MixedSoundError: Error {
+    case fileSaveFailed
+    case invalidData
+    case decodingFailed
+}

--- a/RelaxOn/App/ViewModel/AppState.swift
+++ b/RelaxOn/App/ViewModel/AppState.swift
@@ -1,0 +1,43 @@
+//
+//  AppState.swift
+//  RelaxOn
+//
+//  Created by Doyeon on 2023/04/18.
+//
+
+import SwiftUI
+
+enum TabItems: String {
+    case create = "Create"
+    case listen = "Listen"
+    case relax = "Relax"
+}
+
+enum StarTabBarIcon: String {
+    case starFill = "star.fill"
+}
+
+struct TabItemInfo: Identifiable {
+    let id = UUID()
+    let view: AnyView
+    let imageName: StarTabBarIcon
+    let title: TabItems
+}
+
+/// 전역적인 상태를 관리하는 ViewModel
+/// SoundSaveView 에서 Modal을 dismiss 한 후 Listen 탭으로 이동하기 위해 필요
+final class AppState: ObservableObject {
+    @Published var selectedTab: UUID = UUID()
+    
+    let tabItems = [
+        TabItemInfo(view: AnyView(SoundListView()), imageName: .starFill, title: .create),
+        TabItemInfo(view: AnyView(ListenListView()), imageName: .starFill, title: .listen),
+        TabItemInfo(view: AnyView(RelaxView()), imageName: .starFill, title: .relax)
+    ]
+    
+    func moveToTab(_ tab: TabItems) {
+        if let tabItem = tabItems.first(where: { $0.title == tab }) {
+            selectedTab = tabItem.id
+        }
+    }
+}

--- a/RelaxOn/App/ViewModel/MixedSoundsViewModel.swift
+++ b/RelaxOn/App/ViewModel/MixedSoundsViewModel.swift
@@ -29,4 +29,23 @@ final class MixedSoundsViewModel: ObservableObject {
             print("MixedSound 파일을 삭제하지 못했습니다: \(error.localizedDescription)")
         }
     }
+    
+    func saveMixedSound(_ mixedSound: MixedSound, completion: @escaping (Result<Void, MixedSoundError>) -> Void) {
+        do {
+            try UserFileManager.shared.saveMixedSound(mixedSound)
+            completion(.success(()))
+        } catch {
+            if let mixedSoundError = error as? MixedSoundError {
+                completion(.failure(mixedSoundError))
+            } else {
+                completion(.failure(.fileSaveFailed))
+            }
+        }
+    }
+}
+
+enum MixedSoundError: Error {
+    case fileSaveFailed
+    case invalidData
+    case decodingFailed
 }

--- a/RelaxOn/App/ViewModel/MixedSoundsViewModel.swift
+++ b/RelaxOn/App/ViewModel/MixedSoundsViewModel.swift
@@ -8,5 +8,25 @@
 import Foundation
 
 final class MixedSoundsViewModel: ObservableObject {
-
+    
+    @Published var mixedSounds: [MixedSound] = [] {
+        didSet {
+            UserDefaultsManager.shared.mixedSounds = mixedSounds
+        }
+    }
+    
+    func loadMixedSound() {
+        mixedSounds = UserDefaultsManager.shared.mixedSounds
+    }
+    
+    func removeMixedSound(at index: Int) {
+        let mixedSound = mixedSounds[index]
+        do {
+            try UserFileManager.shared.deleteMixedSound(mixedSound)
+            UserDefaultsManager.shared.removeMixedSound(mixedSound)
+            mixedSounds.remove(at: index)
+        } catch {
+            print("MixedSound 파일을 삭제하지 못했습니다: \(error.localizedDescription)")
+        }
+    }
 }

--- a/RelaxOn/App/ViewModel/MixedSoundsViewModel.swift
+++ b/RelaxOn/App/ViewModel/MixedSoundsViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  MixedSoundsViewModel.swift
+//  RelaxOn
+//
+//  Created by Doyeon on 2023/04/12.
+//
+
+import Foundation
+
+final class MixedSoundsViewModel: ObservableObject {
+
+}

--- a/RelaxOn/App/ViewModel/MixedSoundsViewModel.swift
+++ b/RelaxOn/App/ViewModel/MixedSoundsViewModel.swift
@@ -43,9 +43,3 @@ final class MixedSoundsViewModel: ObservableObject {
         }
     }
 }
-
-enum MixedSoundError: Error {
-    case fileSaveFailed
-    case invalidData
-    case decodingFailed
-}

--- a/RelaxOn/App/Views/Create/SoundDetailView.swift
+++ b/RelaxOn/App/Views/Create/SoundDetailView.swift
@@ -56,7 +56,7 @@ struct SoundDetailView: View {
             
             .fullScreenCover(isPresented: $isShowingSheet) {
                 SoundSaveView(mixedSound: MixedSound(
-                    fileName: originalSound.name,
+                    name: originalSound.name,
                     volume: audioManager.volume,
                     imageName: originalSound.imageName)
                 )

--- a/RelaxOn/App/Views/Create/SoundDetailView.swift
+++ b/RelaxOn/App/Views/Create/SoundDetailView.swift
@@ -9,9 +9,10 @@ import SwiftUI
 import AVFoundation
 
 struct SoundDetailView: View {
+    
     // MARK: - Properties
     @State var isShowingSheet: Bool = false
-    @State var mixedSound: MixedSound
+    @State var originalSound: Sound
     @ObservedObject var audioManager = AudioManager()
     
     var body: some View {
@@ -33,13 +34,13 @@ struct SoundDetailView: View {
             
             Text("Volume Slider")
                 .font(.title3)
-            // 변경되는 volume 값을 전달하기 위한 임시 슬라이더
+            
             Slider(value: audioManager.currentVolume, in: 0.0 ... 1.0)
                 .padding(.horizontal, 20)
                 .padding(.vertical, 10)
         }//VStack
         
-        .navigationBarTitle(mixedSound.fileName, displayMode: .inline)
+        .navigationBarTitle(originalSound.name, displayMode: .inline)
         .font(.system(size: 24, weight: .bold))
         
         .toolbar {
@@ -52,16 +53,20 @@ struct SoundDetailView: View {
                     .bold()
                     .font(.system(size: 20))
             }
-
+            
             .fullScreenCover(isPresented: $isShowingSheet) {
-                SoundSaveView(volume: audioManager.currentVolume)
+                SoundSaveView(mixedSound: MixedSound(
+                    fileName: originalSound.name,
+                    volume: audioManager.volume,
+                    imageName: originalSound.imageName)
+                )
                 
             }
         }
         
         // MARK: - Life Cycle
         .onAppear() {
-            audioManager.playAudio(mixedSound: mixedSound)
+            audioManager.playAudio(sound: originalSound)
         }
         .onDisappear() {
             audioManager.stopAudio()
@@ -71,6 +76,6 @@ struct SoundDetailView: View {
 
 struct SoundDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        SoundDetailView(mixedSound: MixedSound(fileName: "Water Drop", volume: 0.5))
+        SoundDetailView(originalSound: Sound(name: "Water Drop"))
     }
 }

--- a/RelaxOn/App/Views/Create/SoundListView.swift
+++ b/RelaxOn/App/Views/Create/SoundListView.swift
@@ -28,7 +28,7 @@ struct SoundListView: View {
     private func gridView() -> some View {
         LazyVGrid(columns: columns) {
             ForEach(fileNames, id: \.self) { fileName in
-                NavigationLink(destination: SoundDetailView(mixedSound: MixedSound(fileName: fileName, volume: 0.5))) {
+                NavigationLink(destination: SoundDetailView(originalSound: Sound(name: fileName))) {
                     gridViewItem(fileName)
                 }
             }

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -11,6 +11,8 @@ struct SoundSaveView: View {
     
     @Environment(\.presentationMode) var presentationMode
     @FocusState private var isFocused: Bool
+    @State private var isShowingAlert = false
+    @State private var alertMessage = ""
     @State var soundSavedName: String = ""
     @State var mixedSound: MixedSound
     var imageFiles: [String] = ["Recipe1", "Recipe2", "Recipe3", "Recipe4", "Recipe5",
@@ -38,8 +40,11 @@ struct SoundSaveView: View {
                         let newMixedSound = MixedSound(fileName: soundSavedName, imageName: mixedSound.imageName)
                         do {
                             try UserFileManager.shared.saveMixedSound(newMixedSound)
+                            presentationMode.wrappedValue.dismiss() // 성공적으로 저장되면 dismiss
                         } catch {
                             print(error.localizedDescription)
+                            isShowingAlert = true
+                            alertMessage = "저장에 실패했습니다. \(error.localizedDescription)"
                         }
                     } label: {
                         Text("Save")
@@ -84,6 +89,9 @@ struct SoundSaveView: View {
         .background(Color.white)
         .onTapGesture {
             isFocused = false
+        }
+        .alert(isPresented: $isShowingAlert) {
+            Alert(title: Text("Error"), message: Text(alertMessage), dismissButton: .default(Text("OK")))
         }
     }
 }

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -53,11 +53,10 @@ struct SoundSaveView: View {
                     }.offset(x: 0, y: -70)
                 }
 
-                TextField("\(mixedSound.name)", text: $soundSavedName)
-                    .frame(minWidth: 150, idealWidth: 150, maxWidth: 300,
-                           minHeight: 80, idealHeight: 80, maxHeight: 80,
-                           alignment: .center)
-                    .padding(EdgeInsets(top: 100, leading: 180, bottom: 100, trailing: 150))
+                TextField(mixedSound.name, text: $soundSavedName)
+                    .frame(width: 300, height: 80, alignment: .center)
+                    .multilineTextAlignment(.center)
+                    .padding(EdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30))
                     .keyboardType(.default)
                     .autocorrectionDisabled(true)
                     .focused($isFocused)

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SoundSaveView: View {
     
+    @Environment(\.presentationMode) var presentationMode
     @FocusState private var isFocused: Bool
     @State var soundSavedName: String = ""
     @State var mixedSound: MixedSound
@@ -20,7 +21,7 @@ struct SoundSaveView: View {
             VStack{
                 HStack{
                     Button {
-                        print("cancel")
+                        presentationMode.wrappedValue.dismiss()
                     } label: {
                         Text("Cancel")
                             .foregroundColor(.black)

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -33,7 +33,6 @@ struct SoundSaveView: View {
                     Spacer()
 
                     Button {
-                        print("save")
                         isFocused = false
                     } label: {
                         Text("Save")

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -9,12 +9,6 @@ import SwiftUI
 
 struct SoundSaveView: View {
     
-    //var soundName: String = "Sound Name"
-    //@Binding var volume: Float
-
-    //@State var randomImageFileNumber = 1
-    //@State var randomIndex: Int = 0
-    
     @FocusState private var isFocused: Bool
     @State var soundSavedName: String = ""
     @State var mixedSound: MixedSound

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SoundSaveView: View {
     
     @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject var appState: AppState
     @FocusState private var isFocused: Bool
     @State private var isShowingAlert = false
     @State private var alertMessage = ""
@@ -32,12 +33,12 @@ struct SoundSaveView: View {
                 Spacer()
                 
                 Button {
-                    print("save")
                     isFocused = false
                     let newMixedSound = MixedSound(name: soundSavedName, imageName: mixedSound.imageName)
                     do {
                         try UserFileManager.shared.saveMixedSound(newMixedSound)
-                        presentationMode.wrappedValue.dismiss() // 성공적으로 저장되면 dismiss
+                        appState.selectedTab = 1 // ListenListView 탭으로 이동
+                        presentationMode.wrappedValue.dismiss()
                     } catch {
                         print(error.localizedDescription)
                         isShowingAlert = true
@@ -55,7 +56,7 @@ struct SoundSaveView: View {
             TextField(mixedSound.name, text: $soundSavedName)
                 .frame(width: 300, height: 80, alignment: .center)
                 .multilineTextAlignment(.center)
-                .padding(EdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30))
+                .padding(.horizontal, 30)
                 .keyboardType(.default)
                 .autocorrectionDisabled(true)
                 .focused($isFocused)
@@ -67,7 +68,7 @@ struct SoundSaveView: View {
                     .resizable()
                     .frame(width: 300, height: 300)
                 Button {
-                    print("이미지 변경 버튼")
+                    print("이미지 변경 버튼 탭")
                     mixedSound.imageName = recipeRandomName.randomElement()!
                 } label: {
                     Image(systemName: "arrow.triangle.2.circlepath")
@@ -78,9 +79,7 @@ struct SoundSaveView: View {
                 }.offset(x: 120, y: -120)
             }
         }
-        .onAppear {
-            isFocused = true
-        }
+        .onAppear { isFocused = true }
         .background(Color.white)
         .onTapGesture {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -39,7 +39,7 @@ struct SoundSaveView: View {
                     viewModel.saveMixedSound(newMixedSound) { result in
                         switch result {
                         case .success:
-                            appState.selectedTab = 1 // ListenListView 탭으로 이동
+                            appState.moveToTab(.listen) // ListenListView 탭으로 이동
                             presentationMode.wrappedValue.dismiss()
                         case .failure(let error):
                             switch error {

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -9,21 +9,22 @@ import SwiftUI
 
 struct SoundSaveView: View {
     
+    //var soundName: String = "Sound Name"
+    //@Binding var volume: Float
+
+    //@State var randomImageFileNumber = 1
+    //@State var randomIndex: Int = 0
+    
     @FocusState private var isFocused: Bool
-    @Binding var volume: Float
-    var soundName: String = "Sound Name"
     @State var soundSavedName: String = ""
-    @State var randomImageFileNumber = 1
+    @State var mixedSound: MixedSound
     var imageFiles: [String] = ["Recipe1", "Recipe2", "Recipe3", "Recipe4", "Recipe5",
                                 "Recipe6", "Recipe7", "Recipe8", "Recipe9", "Recipe10"]
-    @State var randomIndex: Int = 0
-    
+
     var body: some View {
         ZStack{
             VStack{
                 HStack{
-                    
-                    //취소 버튼
                     Button {
                         print("cancel")
                     } label: {
@@ -35,8 +36,7 @@ struct SoundSaveView: View {
                     }.offset(x: 0, y: -70)
                     
                     Spacer()
-                    
-                    //저장 버튼
+
                     Button {
                         print("save")
                         isFocused = false
@@ -48,9 +48,8 @@ struct SoundSaveView: View {
                             .padding(10)
                     }.offset(x: 0, y: -70)
                 }
-                
-                //제목 입력
-                TextField("\(soundName)", text: $soundSavedName)
+
+                TextField("\(mixedSound.fileName)", text: $soundSavedName)
                     .frame(minWidth: 150, idealWidth: 150, maxWidth: 300,
                            minHeight: 80, idealHeight: 80, maxHeight: 80,
                            alignment: .center)
@@ -62,14 +61,11 @@ struct SoundSaveView: View {
                     .underline(true)
                 
                 ZStack{
-                    //앨범 이미지
-                    Image(imageFiles[randomIndex])
+                    Image(mixedSound.imageName)
                         .resizable()
                         .frame(width: 300, height: 300)
-                    
-                    //이미지변경 버튼
                     Button {
-                        randomIndex = Int.random(in: 0..<imageFiles.count)
+                        print("이미지 변경 버튼")
                     } label: {
                         Image(systemName: "arrow.triangle.2.circlepath")
                             .resizable()
@@ -94,6 +90,6 @@ struct SoundSaveView: View {
 
 struct SoundSaveView_Previews: PreviewProvider {
     static var previews: some View {
-        SoundSaveView(volume: .constant(Float()))
+        SoundSaveView(mixedSound: MixedSound(fileName: "Water Drop"))
     }
 }

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -15,8 +15,6 @@ struct SoundSaveView: View {
     @State private var alertMessage = ""
     @State var soundSavedName: String = ""
     @State var mixedSound: MixedSound
-    var imageFiles: [String] = ["Recipe1", "Recipe2", "Recipe3", "Recipe4", "Recipe5",
-                                "Recipe6", "Recipe7", "Recipe8", "Recipe9", "Recipe10"]
 
     var body: some View {
         ZStack{

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -15,77 +15,75 @@ struct SoundSaveView: View {
     @State private var alertMessage = ""
     @State var soundSavedName: String = ""
     @State var mixedSound: MixedSound
-
+    
     var body: some View {
-        ZStack{
-            VStack{
-                HStack{
-                    Button {
-                        presentationMode.wrappedValue.dismiss()
-                    } label: {
-                        Text("Cancel")
-                            .foregroundColor(.black)
-                            .font(.system(size: 20))
-                            .bold()
-                            .padding(10)
-                    }.offset(x: 0, y: -70)
-                    
-                    Spacer()
-
-                    Button {
-                        print("save")
-                        isFocused = false
-                        let newMixedSound = MixedSound(name: soundSavedName, imageName: mixedSound.imageName)
-                        do {
-                            try UserFileManager.shared.saveMixedSound(newMixedSound)
-                            presentationMode.wrappedValue.dismiss() // 성공적으로 저장되면 dismiss
-                        } catch {
-                            print(error.localizedDescription)
-                            isShowingAlert = true
-                            alertMessage = "저장에 실패했습니다. \(error.localizedDescription)"
-                        }
-                    } label: {
-                        Text("Save")
-                            .foregroundColor(.black)
-                            .font(.system(size: 20))
-                            .bold()
-                            .padding(10)
-                    }.offset(x: 0, y: -70)
-                }
-
-                TextField(mixedSound.name, text: $soundSavedName)
-                    .frame(width: 300, height: 80, alignment: .center)
-                    .multilineTextAlignment(.center)
-                    .padding(EdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30))
-                    .keyboardType(.default)
-                    .autocorrectionDisabled(true)
-                    .focused($isFocused)
-                    .font(.title)
-                    .underline(true)
+        VStack{
+            HStack{
+                Button {
+                    presentationMode.wrappedValue.dismiss()
+                } label: {
+                    Text("Cancel")
+                        .foregroundColor(.black)
+                        .font(.system(size: 20))
+                        .bold()
+                        .padding(10)
+                }.offset(x: 0, y: -70)
                 
-                ZStack{
-                    Image(mixedSound.imageName)
+                Spacer()
+                
+                Button {
+                    print("save")
+                    isFocused = false
+                    let newMixedSound = MixedSound(name: soundSavedName, imageName: mixedSound.imageName)
+                    do {
+                        try UserFileManager.shared.saveMixedSound(newMixedSound)
+                        presentationMode.wrappedValue.dismiss() // 성공적으로 저장되면 dismiss
+                    } catch {
+                        print(error.localizedDescription)
+                        isShowingAlert = true
+                        alertMessage = "저장에 실패했습니다. \(error.localizedDescription)"
+                    }
+                } label: {
+                    Text("Save")
+                        .foregroundColor(.black)
+                        .font(.system(size: 20))
+                        .bold()
+                        .padding(10)
+                }.offset(x: 0, y: -70)
+            }
+            
+            TextField(mixedSound.name, text: $soundSavedName)
+                .frame(width: 300, height: 80, alignment: .center)
+                .multilineTextAlignment(.center)
+                .padding(EdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30))
+                .keyboardType(.default)
+                .autocorrectionDisabled(true)
+                .focused($isFocused)
+                .font(.title)
+                .underline(true)
+            
+            ZStack{
+                Image(mixedSound.imageName)
+                    .resizable()
+                    .frame(width: 300, height: 300)
+                Button {
+                    print("이미지 변경 버튼")
+                    mixedSound.imageName = recipeRandomName.randomElement()!
+                } label: {
+                    Image(systemName: "arrow.triangle.2.circlepath")
                         .resizable()
-                        .frame(width: 300, height: 300)
-                    Button {
-                        print("이미지 변경 버튼")
-                        mixedSound.imageName = recipeRandomName.randomElement()!
-                    } label: {
-                        Image(systemName: "arrow.triangle.2.circlepath")
-                            .resizable()
-                            .frame(width: 24, height: 24)
-                            .foregroundColor(.black)
-                            .bold()
-                    }.offset(x: 120, y: -120)
-                }
+                        .frame(width: 24, height: 24)
+                        .foregroundColor(.black)
+                        .bold()
+                }.offset(x: 120, y: -120)
             }
-            .onAppear {
-                isFocused = true
-            }
+        }
+        .onAppear {
+            isFocused = true
         }
         .background(Color.white)
         .onTapGesture {
-            isFocused = false
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
         .alert(isPresented: $isShowingAlert) {
             Alert(title: Text("Error"), message: Text(alertMessage), dismissButton: .default(Text("OK")))

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -72,13 +72,13 @@ struct SoundSaveView: View {
                         .frame(width: 300, height: 300)
                     Button {
                         print("이미지 변경 버튼")
+                        mixedSound.imageName = recipeRandomName.randomElement()!
                     } label: {
                         Image(systemName: "arrow.triangle.2.circlepath")
                             .resizable()
                             .frame(width: 24, height: 24)
                             .foregroundColor(.black)
                             .bold()
-                        
                     }.offset(x: 120, y: -120)
                 }
             }

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -33,7 +33,14 @@ struct SoundSaveView: View {
                     Spacer()
 
                     Button {
+                        print("save")
                         isFocused = false
+                        let newMixedSound = MixedSound(fileName: soundSavedName, imageName: mixedSound.imageName)
+                        do {
+                            try UserFileManager.shared.saveMixedSound(newMixedSound)
+                        } catch {
+                            print(error.localizedDescription)
+                        }
                     } label: {
                         Text("Save")
                             .foregroundColor(.black)

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -37,7 +37,7 @@ struct SoundSaveView: View {
                     Button {
                         print("save")
                         isFocused = false
-                        let newMixedSound = MixedSound(fileName: soundSavedName, imageName: mixedSound.imageName)
+                        let newMixedSound = MixedSound(name: soundSavedName, imageName: mixedSound.imageName)
                         do {
                             try UserFileManager.shared.saveMixedSound(newMixedSound)
                             presentationMode.wrappedValue.dismiss() // 성공적으로 저장되면 dismiss
@@ -55,7 +55,7 @@ struct SoundSaveView: View {
                     }.offset(x: 0, y: -70)
                 }
 
-                TextField("\(mixedSound.fileName)", text: $soundSavedName)
+                TextField("\(mixedSound.name)", text: $soundSavedName)
                     .frame(minWidth: 150, idealWidth: 150, maxWidth: 300,
                            minHeight: 80, idealHeight: 80, maxHeight: 80,
                            alignment: .center)
@@ -99,6 +99,6 @@ struct SoundSaveView: View {
 
 struct SoundSaveView_Previews: PreviewProvider {
     static var previews: some View {
-        SoundSaveView(mixedSound: MixedSound(fileName: "Water Drop"))
+        SoundSaveView(mixedSound: MixedSound(name: "Water Drop"))
     }
 }

--- a/RelaxOn/App/Views/Listen/ListenListView.swift
+++ b/RelaxOn/App/Views/Listen/ListenListView.swift
@@ -16,7 +16,7 @@ struct ListenListView: View {
         NavigationView {
             List {
                 ForEach(items, id: \.id) { item in
-                    ListenListCell(title: item.fileName, ImageName: item.imageName)
+                    ListenListCell(title: item.name, ImageName: item.imageName)
                 }
                 .onDelete { indexSet in
                     items.remove(atOffsets: indexSet)

--- a/RelaxOn/App/Views/Listen/ListenListView.swift
+++ b/RelaxOn/App/Views/Listen/ListenListView.swift
@@ -9,16 +9,15 @@ import SwiftUI
 
 struct ListenListView: View {
     
-    @State private var items = ["My Water Drop", "Peaceful Water Sound"]
+    
+    @State private var items: [MixedSound] = []
     
     // MARK: - Body
     var body: some View {
-        // TODO: 1. 커스텀 셀 구현 - 이미지 + 제목 + 재생/정지 버튼
-        // TODO: 2. 밀어서 Remove
         NavigationView {
             List {
-                ForEach(items, id: \.self) { item in
-                    ListenListCell(title: item, ImageName: "photo")
+                ForEach(items, id: \.id) { item in
+                    ListenListCell(title: item.fileName, ImageName: item.imageName)
                 }
                 .onDelete { indexSet in
                     items.remove(atOffsets: indexSet)
@@ -26,8 +25,18 @@ struct ListenListView: View {
             }
             .navigationTitle("Listen")
             .navigationBarTitleDisplayMode(.large)
+            .onAppear {
+                loadMixedSounds()
+            }
         }
-        
+    }
+    
+    private func loadMixedSounds() {
+        do {
+            items = try UserFileManager.shared.loadAllMixedSounds()
+        } catch {
+            print(error.localizedDescription)
+        }
     }
 }
 

--- a/RelaxOn/App/Views/Listen/ListenListView.swift
+++ b/RelaxOn/App/Views/Listen/ListenListView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct ListenListView: View {
     
-    
     @State private var items: [MixedSound] = []
     
     // MARK: - Body
@@ -26,16 +25,12 @@ struct ListenListView: View {
             .navigationTitle("Listen")
             .navigationBarTitleDisplayMode(.large)
             .onAppear {
-                loadMixedSounds()
+                do {
+                    items = try UserFileManager.shared.loadAllMixedSounds()
+                } catch {
+                    print(error.localizedDescription)
+                }
             }
-        }
-    }
-    
-    private func loadMixedSounds() {
-        do {
-            items = try UserFileManager.shared.loadAllMixedSounds()
-        } catch {
-            print(error.localizedDescription)
         }
     }
 }

--- a/RelaxOn/App/Views/Listen/ListenListView.swift
+++ b/RelaxOn/App/Views/Listen/ListenListView.swift
@@ -19,7 +19,9 @@ struct ListenListView: View {
                     ListenListCell(title: mixedSound.name, ImageName: mixedSound.imageName)
                 }
                 .onDelete { indexSet in
-                    viewModel.mixedSounds.remove(atOffsets: indexSet)
+                    for index in indexSet {
+                        viewModel.removeMixedSound(at: index)
+                    }
                 }
             }
             .navigationTitle("Listen")

--- a/RelaxOn/App/Views/Listen/ListenListView.swift
+++ b/RelaxOn/App/Views/Listen/ListenListView.swift
@@ -9,27 +9,23 @@ import SwiftUI
 
 struct ListenListView: View {
     
-    @State private var items: [MixedSound] = []
+    @ObservedObject private var viewModel = MixedSoundsViewModel()
     
     // MARK: - Body
     var body: some View {
         NavigationView {
             List {
-                ForEach(items, id: \.id) { item in
-                    ListenListCell(title: item.name, ImageName: item.imageName)
+                ForEach(viewModel.mixedSounds, id: \.id) { mixedSound in
+                    ListenListCell(title: mixedSound.name, ImageName: mixedSound.imageName)
                 }
                 .onDelete { indexSet in
-                    items.remove(atOffsets: indexSet)
+                    viewModel.mixedSounds.remove(atOffsets: indexSet)
                 }
             }
             .navigationTitle("Listen")
             .navigationBarTitleDisplayMode(.large)
             .onAppear {
-                do {
-                    items = try UserFileManager.shared.loadAllMixedSounds()
-                } catch {
-                    print(error.localizedDescription)
-                }
+                viewModel.loadMixedSound()
             }
         }
     }

--- a/RelaxOn/App/Views/Listen/ListenListView.swift
+++ b/RelaxOn/App/Views/Listen/ListenListView.swift
@@ -43,7 +43,7 @@ struct ListenListCell: View {
     
     var body: some View {
         HStack {
-            Image(systemName: ImageName)
+            Image(ImageName)
                 .frame(width: 60, height: 60)
                 .background(.foreground.opacity(0.08)).cornerRadius(10)
                 .offset(x: -10, y: 0)

--- a/RelaxOn/App/Views/MainTabView.swift
+++ b/RelaxOn/App/Views/MainTabView.swift
@@ -12,21 +12,14 @@ struct MainTabView: View {
     
     var body: some View {
         TabView(selection: $appState.selectedTab) {
-            SoundListView()
-                .tabItem {
-                    Image(systemName: "star.fill")
-                    Text("Create")
-                }.tag(0)
-            ListenListView()
-                .tabItem {
-                    Image(systemName: "star.fill")
-                    Text("Listen")
-                }.tag(1)
-            RelaxView()
-                .tabItem {
-                    Image(systemName: "star.fill")
-                    Text("Relax")
-                }.tag(2)
+            ForEach(appState.tabItems) { item in
+                item.view
+                    .tabItem {
+                        Image(systemName: item.imageName.rawValue)
+                            .foregroundColor(.black)
+                        Text(item.title.rawValue)
+                    }.tag(item.id)
+            }
         }
         .environmentObject(appState)
     }

--- a/RelaxOn/App/Views/MainTabView.swift
+++ b/RelaxOn/App/Views/MainTabView.swift
@@ -8,24 +8,27 @@
 import SwiftUI
 
 struct MainTabView: View {
+    @StateObject var appState = AppState()
+    
     var body: some View {
-        TabView {
+        TabView(selection: $appState.selectedTab) {
             SoundListView()
-            .tabItem {
-                Image(systemName: "star.fill")
-                Text("Create")
-            }
+                .tabItem {
+                    Image(systemName: "star.fill")
+                    Text("Create")
+                }.tag(0)
             ListenListView()
                 .tabItem {
                     Image(systemName: "star.fill")
                     Text("Listen")
-                }
+                }.tag(1)
             RelaxView()
                 .tabItem {
                     Image(systemName: "star.fill")
                     Text("Relax")
-                }
+                }.tag(2)
         }
+        .environmentObject(appState)
     }
 }
 


### PR DESCRIPTION
## 작업 내용 (Content)
### MixedSound 구조 수정
- init 할 때 `id` 를 `UUID`생성하는 것으로 수정했습니다.
```swift
struct MixedSound: Hashable, Codable {
    let id: UUID            // 생성된 MixedSound의 고유 아이디
    var fileName: String    // Original Sound의 fileName
    var volume: Float       // 저장할 볼륨 값
    var imageName: String   // 저장할 이미지
    
    init(fileName: String, volume: Float = 0.5, imageName: String = recipeRandomName.randomElement()!) {
        self.id = UUID()
        self.fileName = fileName
        self.volume = volume
        self.imageName = imageName
    }
}
```

### `UserFileManager.swift` 생성
현재 코드 기준 사용법은 아래 예시와 같습니다.

앱의 문서 디렉터리에 `MixedSound` 객체를 저장하려면:

```swift
let mixedSound = MixedSound(id: UUID(), name: "예제 사운드")
do {
    try UserFileManager.shared.saveMixedSound(mixedSound)
} catch {
    print("믹스된 사운드 저장 오류: \(error.localizedDescription)")
}

앱의 문서 디렉터리에서 MixedSound 객체를 삭제하려면:

```swift
let mixedSoundToDelete = MixedSound(id: UUID(), name: "예제 사운드")
do {
    try UserFileManager.shared.deleteMixedSound(mixedSoundToDelete)
} catch UserFileManagerError.fileNotFound {
    print("오류: 파일을 찾을 수 없습니다")
} catch {
    print("믹스된 사운드 삭제 오류: \(error.localizedDescription)")
}
```

앱의 문서 디렉터리에서 모든 MixedSound 객체를 불러오려면:
```swift
do {
    let mixedSounds = try UserFileManager.shared.loadAllMixedSounds()
    print("불러온 믹스된 사운드: \(mixedSounds)")
} catch {
    print("믹스된 사운드 불러오기 오류: \(error.localizedDescription)")
}
```

## 기타 사항 (Etc)
### 추후 수정할 내용
- Save버튼을 눌렀을 때 바로 Listen 탭으로 넘어가도록 수정
- SaveView의 이미지 변경 버튼 작동하도록 수정

## 관련 사진(Optional)

![Simulator Screen Recording - iPhone 14 Pro - 2023-03-29 at 19 29 00](https://user-images.githubusercontent.com/108422901/228526635-e88dd60d-a597-406d-b013-61ab980d0678.gif)
