### PR TITLE
🎨[Design]: SoundSaveView UI

### DIFF
--- a/RelaxOn/App/Views/Create/SoundDetailView.swift
+++ b/RelaxOn/App/Views/Create/SoundDetailView.swift
@@ -29,7 +29,7 @@ struct SoundDetailView: View {
                     .frame(width: 30, height: 30)
                     .offset(x: -15, y: 10)
                     .zIndex(1)
-            }//ZStack
+            }
             .padding(24)
             
             Text("Volume Slider")
@@ -38,7 +38,7 @@ struct SoundDetailView: View {
             Slider(value: audioManager.currentVolume, in: 0.0 ... 1.0)
                 .padding(.horizontal, 20)
                 .padding(.vertical, 10)
-        }//VStack
+        }
         
         .navigationBarTitle(originalSound.name, displayMode: .inline)
         .font(.system(size: 24, weight: .bold))

--- a/RelaxOn/App/Views/Create/SoundDetailView.swift
+++ b/RelaxOn/App/Views/Create/SoundDetailView.swift
@@ -60,7 +60,6 @@ struct SoundDetailView: View {
                     volume: audioManager.volume,
                     imageName: originalSound.imageName)
                 )
-                
             }
         }
         

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -20,11 +20,10 @@ struct SoundSaveView: View {
     
     var body: some View {
         VStack{
-            HStack{
+            HStack(alignment: .center){
                 Button {
                     presentationMode.wrappedValue.dismiss()
                 } label: {
-                    // Text"Cancel" -> Image
                     Image(systemName: "chevron.backward")
                         .resizable()
                         .frame(width: 10, height: 20)
@@ -32,8 +31,6 @@ struct SoundSaveView: View {
                         .foregroundColor(.gray)
                 }
                 .offset(x: 15, y: -70)
-                // 각 UI에 크기를 제한하여 제목이 중앙에 오도록 유도
-                .frame(width: 30)
                 
                 Spacer()
                 
@@ -67,16 +64,12 @@ struct SoundSaveView: View {
                         }
                     }
                 } label: {
-                    // Save -> 저장
                     Text("저장")
                         .foregroundColor(.black)
                         .font(.system(size: 15))
                         .bold()
-                }
-                .offset(x: -10, y: -70)
-                .frame(width: 30)
+                }.offset(x: -10, y: -70)
                 
-            //HStack에 크기를 제한함
             }.frame(width: 400)
             
             TextField(mixedSound.name, text: $soundSavedName)
@@ -93,7 +86,6 @@ struct SoundSaveView: View {
                 Image(mixedSound.imageName)
                     .resizable()
                     .frame(width: 300, height: 300)
-                // 사진에 굴곡 추가
                     .cornerRadius(12)
                 Button {
                     print("이미지 변경 버튼 탭")

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -24,12 +24,23 @@ struct SoundSaveView: View {
                 Button {
                     presentationMode.wrappedValue.dismiss()
                 } label: {
-                    Text("Cancel")
-                        .foregroundColor(.black)
-                        .font(.system(size: 20))
+                    // Text"Cancel" -> Image
+                    Image(systemName: "chevron.backward")
+                        .resizable()
+                        .frame(width: 10, height: 20)
                         .bold()
-                        .padding(10)
-                }.offset(x: 0, y: -70)
+                        .foregroundColor(.gray)
+                }
+                .offset(x: 15, y: -70)
+                // 각 UI에 크기를 제한하여 제목이 중앙에 오도록 유도
+                .frame(width: 30)
+                
+                Spacer()
+                
+                // 선택한 사운드의 제목
+                Text(mixedSound.name)
+                    .font(.system(size: 24, weight: .bold))
+                    .offset(y: -70)
                 
                 Spacer()
                 
@@ -56,16 +67,20 @@ struct SoundSaveView: View {
                         }
                     }
                 } label: {
-                    Text("Save")
+                    // Save -> 저장
+                    Text("저장")
                         .foregroundColor(.black)
-                        .font(.system(size: 20))
+                        .font(.system(size: 15))
                         .bold()
-                        .padding(10)
-                }.offset(x: 0, y: -70)
-            }
+                }
+                .offset(x: -10, y: -70)
+                .frame(width: 30)
+                
+            //HStack에 크기를 제한함
+            }.frame(width: 400)
             
             TextField(mixedSound.name, text: $soundSavedName)
-                .frame(width: 300, height: 80, alignment: .center)
+                .frame(width: 160, height: 80, alignment: .center)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 30)
                 .keyboardType(.default)
@@ -78,6 +93,8 @@ struct SoundSaveView: View {
                 Image(mixedSound.imageName)
                     .resizable()
                     .frame(width: 300, height: 300)
+                // 사진에 굴곡 추가
+                    .cornerRadius(12)
                 Button {
                     print("이미지 변경 버튼 탭")
                     mixedSound.imageName = recipeRandomName.randomElement()!

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -34,7 +34,6 @@ struct SoundSaveView: View {
                 
                 Spacer()
                 
-                // 선택한 사운드의 제목
                 Text(mixedSound.name)
                     .font(.system(size: 24, weight: .bold))
                     .offset(y: -70)

--- a/RelaxOn/App/Views/Create/SoundSaveView.swift
+++ b/RelaxOn/App/Views/Create/SoundSaveView.swift
@@ -46,7 +46,7 @@ struct SoundSaveView: View {
                     viewModel.saveMixedSound(newMixedSound) { result in
                         switch result {
                         case .success:
-                            appState.moveToTab(.listen) // ListenListView 탭으로 이동
+                            appState.moveToTab(.listen)
                             presentationMode.wrappedValue.dismiss()
                         case .failure(let error):
                             switch error {


### PR DESCRIPTION
## 작업 내용 (Content)
- Figma 파일 기준으로 기존의 UI를 수정하였습니다!
- 선택한 사운드 이름이 상단에 표시
- 사진에 굴곡 추가
- Cancel, Save를 버튼 이미지와 저장으로 변경

## 기타 사항 (Etc)
- 각 UI에 마다 Frame을 씌워서 위치를 정렬하였으나 이는 iPhone14 Pro 기준임

## 관련 사진(Optional)
<img width="158" alt="image" src="https://user-images.githubusercontent.com/109560875/234199485-d6050b29-9a57-429a-937a-06377fe879fd.png">

<img width="158" alt="image" src="https://user-images.githubusercontent.com/109560875/234199917-ae4361b5-1424-4c2b-ac63-69a5f1b4403f.png">


