### PR TITLE
🐛[Fix]: Timer 실행 오류

### DIFF
--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -45,7 +45,7 @@
 		58DE61C72843100100F25769 /* VolumeControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DE61C62843100100F25769 /* VolumeControlView.swift */; };
 		591570B429F93A5400507DEA /* TimerProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591570B329F93A5400507DEA /* TimerProgressView.swift */; };
 		591570B629F93A7000507DEA /* Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591570B529F93A7000507DEA /* Time.swift */; };
-        5998261C29EF73F600F10B54 /* SoundPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5998261B29EF73F600F10B54 /* SoundPlayerView.swift */; };
+		5998261C29EF73F600F10B54 /* SoundPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5998261B29EF73F600F10B54 /* SoundPlayerView.swift */; };
 		8F0FC48F29C1D9D500F923A5 /* MixedSound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0FC48E29C1D9D500F923A5 /* MixedSound.swift */; };
 		8F0FC49129C1D9F500F923A5 /* Sound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0FC49029C1D9F500F923A5 /* Sound.swift */; };
 		8F0FC49B29C1DD5D00F923A5 /* OldAudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0FC49829C1DD5D00F923A5 /* OldAudioManager.swift */; };
@@ -178,7 +178,7 @@
 		58DE61C62843100100F25769 /* VolumeControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeControlView.swift; sourceTree = "<group>"; };
 		591570B329F93A5400507DEA /* TimerProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerProgressView.swift; sourceTree = "<group>"; };
 		591570B529F93A7000507DEA /* Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Time.swift; sourceTree = "<group>"; };
-        5998261B29EF73F600F10B54 /* SoundPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundPlayerView.swift; sourceTree = "<group>"; };
+		5998261B29EF73F600F10B54 /* SoundPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundPlayerView.swift; sourceTree = "<group>"; };
 		8F0FC48E29C1D9D500F923A5 /* MixedSound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedSound.swift; sourceTree = "<group>"; };
 		8F0FC49029C1D9F500F923A5 /* Sound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sound.swift; sourceTree = "<group>"; };
 		8F0FC49829C1DD5D00F923A5 /* OldAudioManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldAudioManager.swift; sourceTree = "<group>"; };
@@ -525,7 +525,7 @@
 		8F4E1B6929B9B3890013599C /* Listen */ = {
 			isa = PBXGroup;
 			children = (
-                5998261B29EF73F600F10B54 /* SoundPlayerView.swift */,
+				5998261B29EF73F600F10B54 /* SoundPlayerView.swift */,
 				8F4E1B6229B9A5AE0013599C /* ListenListView.swift */,
 			);
 			path = Listen;
@@ -534,8 +534,8 @@
 		8F4E1B6A29B9B3900013599C /* Relax */ = {
 			isa = PBXGroup;
 			children = (
-                591570B329F93A5400507DEA /* TimerProgressView.swift */,
 				8F4E1B6429B9A67E0013599C /* RelaxView.swift */,
+				591570B329F93A5400507DEA /* TimerProgressView.swift */,
 			);
 			path = Relax;
 			sourceTree = "<group>";
@@ -543,10 +543,9 @@
 		8F4E1B6B29B9BE240013599C /* Models */ = {
 			isa = PBXGroup;
 			children = (
-                591570B529F93A7000507DEA /* Time.swift */,
+				591570B529F93A7000507DEA /* Time.swift */,
 				8F0FC48E29C1D9D500F923A5 /* MixedSound.swift */,
 				8F0FC49029C1D9F500F923A5 /* Sound.swift */,
-				
 			);
 			path = Models;
 			sourceTree = "<group>";

--- a/RelaxOn/App/Views/Relax/RelaxView.swift
+++ b/RelaxOn/App/Views/Relax/RelaxView.swift
@@ -53,7 +53,7 @@ struct RelaxView: View {
                     Text("min")
                 }.frame(width: 300, height: 300)
             } else {
-                TimerProgressView(isShowingTimerProgressView: isShowingTimerProgressView, progress: $progress)
+                TimerProgressView(timeData: timeData, isShowingTimerProgressView: isShowingTimerProgressView, progress: $progress)
             }
             
             Button {

--- a/RelaxOn/App/Views/Relax/TimerProgressView.swift
+++ b/RelaxOn/App/Views/Relax/TimerProgressView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct TimerProgressView: View {
 
     @State var timer: Timer?
-    @ObservedObject var timeData = Time()
+    @ObservedObject var timeData: Time
     @State var remainingSeconds: Int = 0
     @State var isShowingTimerProgressView: Bool = false
     @Binding var progress: Double


### PR DESCRIPTION
## 작업 내용 (Content)
- RelaxView에서 시간을 선택하고 실행해도 타이머가 실행되지 않는 버그를 발견하여 수정
- Print문을 통해서 데이터 유실이 이루어지는 부분이 어디인지 파악
  - 시간선택하고 Start를 누른 시점과 TimerProgressView가 시작된 시점
  - TimerProgressView에서 유실됨을 확인
### 문제
- 각 뷰의 ObservedObject 인스턴스 값이 다름
### 원인
- Time이라는 하나의 클래스를 관찰하는 ObservedObject이지만 각각 다른 인스턴스를 가지고 있었음.
- 하나의 클래스를 관찰하는 인스턴스라도 각 인스턴스는 독립성을 지닌 객체로써 서로 다른 값을 가질 확률이 있음
- 그렇기 때문에 RelaxView에서 변경된 값을 2번 뷰에서도 업데이트할려면 해당 인스턴스를 공유해야하는데 
 다른 인스턴스를 가지고 있었기에 다른 값을 가지고있었다고 생각함
### 해결방법
- RelaxView에서 생성한 ObservedObject 인스턴스를 TimerProgressView에 전달하여 동일한 인스턴스로 Time에 접근

## 기타 사항 (Etc)
- 급한 내용이라 생각하여 해당 이슈만 해결하고 PR 요청합니다


## Close Issues
- Close #380  


## 관련 사진(Optional)
![Simulator Screen Recording - iPhone 14 Pro - 2023-05-12 at 14 32 09](https://github.com/M1zz/RelaxOn/assets/109560875/9c09b841-7fba-4202-8d09-2cca979ed62e)
