### PR TITLE
🐛 [Fix]: CircularSlider 분리 & FilterSlider 애니메이션 보완

### DIFF
--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		58DE61C72843100100F25769 /* VolumeControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DE61C62843100100F25769 /* VolumeControlView.swift */; };
 		591570B429F93A5400507DEA /* TimerProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591570B329F93A5400507DEA /* TimerProgressView.swift */; };
 		591570B629F93A7000507DEA /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591570B529F93A7000507DEA /* TimerManager.swift */; };
+		5931DC9D2A3B1D6000FFEF17 /* SnapCircularSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5931DC9C2A3B1D6000FFEF17 /* SnapCircularSlider.swift */; };
 		5940125A2A17DCC400221DE7 /* Sink.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 594012592A17DCC300221DE7 /* Sink.mp3 */; };
 		5940125F2A17DCEB00221DE7 /* Basement.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 5940125B2A17DCEA00221DE7 /* Basement.mp3 */; };
 		594012612A17DCEB00221DE7 /* Cave.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 5940125D2A17DCEA00221DE7 /* Cave.mp3 */; };
@@ -227,6 +228,7 @@
 		58DE61C62843100100F25769 /* VolumeControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeControlView.swift; sourceTree = "<group>"; };
 		591570B329F93A5400507DEA /* TimerProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerProgressView.swift; sourceTree = "<group>"; };
 		591570B529F93A7000507DEA /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
+		5931DC9C2A3B1D6000FFEF17 /* SnapCircularSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapCircularSlider.swift; sourceTree = "<group>"; };
 		594012592A17DCC300221DE7 /* Sink.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = Sink.mp3; sourceTree = "<group>"; };
 		5940125B2A17DCEA00221DE7 /* Basement.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = Basement.mp3; sourceTree = "<group>"; };
 		5940125D2A17DCEA00221DE7 /* Cave.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = Cave.mp3; sourceTree = "<group>"; };
@@ -754,6 +756,7 @@
 				8F5A0EBE2A15FBDD0061F42C /* SoundPlayerFullModalView.swift */,
 				8F5A0EC22A15FD750061F42C /* CircleProgressView.swift */,
 				59DFA0762A30D65E006EB723 /* CircularSlider.swift */,
+				5931DC9C2A3B1D6000FFEF17 /* SnapCircularSlider.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1023,6 +1026,7 @@
 				8F0FC49B29C1DD5D00F923A5 /* OldAudioManager.swift in Sources */,
 				59DFA0772A30D65E006EB723 /* CircularSlider.swift in Sources */,
 				CBFDC8F4289C23AC00386FB5 /* VolumeSlider.swift in Sources */,
+				5931DC9D2A3B1D6000FFEF17 /* SnapCircularSlider.swift in Sources */,
 				58DE61B2283A8E1700F25769 /* OldSound.swift in Sources */,
 				C7FDCA8C28D094E0008FA749 /* MusicViewDelegate.swift in Sources */,
 				101417F8289EB82200F40397 /* CDCoverImageView.swift in Sources */,

--- a/RelaxOn.xcodeproj/project.pbxproj
+++ b/RelaxOn.xcodeproj/project.pbxproj
@@ -57,7 +57,7 @@
 		594012732A17DD7900221DE7 /* Woodpecker.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 5940126F2A17DD7800221DE7 /* Woodpecker.mp3 */; };
 		594012752A17DD7900221DE7 /* Owl.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 594012712A17DD7800221DE7 /* Owl.mp3 */; };
 		594012762A17DD7900221DE7 /* Forest.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 594012722A17DD7900221DE7 /* Forest.mp3 */; };
-		59DFA0772A30D65E006EB723 /* CircularSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DFA0762A30D65E006EB723 /* CircularSlider.swift */; };
+		59DFA0772A30D65E006EB723 /* DragCircularSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DFA0762A30D65E006EB723 /* DragCircularSlider.swift */; };
 		8F00A2392A2332530062B816 /* TimerSoundSelectModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F00A2382A2332530062B816 /* TimerSoundSelectModalView.swift */; };
 		8F00A23B2A2348C20062B816 /* TimerSoundListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F00A23A2A2348C20062B816 /* TimerSoundListCell.swift */; };
 		8F00A23D2A235E5F0062B816 /* OnboardItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F00A23C2A235E5F0062B816 /* OnboardItem.swift */; };
@@ -240,7 +240,7 @@
 		5940126F2A17DD7800221DE7 /* Woodpecker.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = Woodpecker.mp3; sourceTree = "<group>"; };
 		594012712A17DD7800221DE7 /* Owl.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = Owl.mp3; sourceTree = "<group>"; };
 		594012722A17DD7900221DE7 /* Forest.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = Forest.mp3; sourceTree = "<group>"; };
-		59DFA0762A30D65E006EB723 /* CircularSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularSlider.swift; sourceTree = "<group>"; };
+		59DFA0762A30D65E006EB723 /* DragCircularSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragCircularSlider.swift; sourceTree = "<group>"; };
 		8F00A2382A2332530062B816 /* TimerSoundSelectModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerSoundSelectModalView.swift; sourceTree = "<group>"; };
 		8F00A23A2A2348C20062B816 /* TimerSoundListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerSoundListCell.swift; sourceTree = "<group>"; };
 		8F00A23C2A235E5F0062B816 /* OnboardItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardItem.swift; sourceTree = "<group>"; };
@@ -755,7 +755,7 @@
 				8FCB23F32A15F85200188024 /* SoundPlayerBottomView.swift */,
 				8F5A0EBE2A15FBDD0061F42C /* SoundPlayerFullModalView.swift */,
 				8F5A0EC22A15FD750061F42C /* CircleProgressView.swift */,
-				59DFA0762A30D65E006EB723 /* CircularSlider.swift */,
+				59DFA0762A30D65E006EB723 /* DragCircularSlider.swift */,
 				5931DC9C2A3B1D6000FFEF17 /* SnapCircularSlider.swift */,
 			);
 			path = Components;
@@ -1024,7 +1024,7 @@
 				E206D1A428D2B97500DDB4E7 /* TimerProgressBarView.swift in Sources */,
 				8F31407D29D428B900BB5410 /* UserFileManager.swift in Sources */,
 				8F0FC49B29C1DD5D00F923A5 /* OldAudioManager.swift in Sources */,
-				59DFA0772A30D65E006EB723 /* CircularSlider.swift in Sources */,
+				59DFA0772A30D65E006EB723 /* DragCircularSlider.swift in Sources */,
 				CBFDC8F4289C23AC00386FB5 /* VolumeSlider.swift in Sources */,
 				5931DC9D2A3B1D6000FFEF17 /* SnapCircularSlider.swift in Sources */,
 				58DE61B2283A8E1700F25769 /* OldSound.swift in Sources */,

--- a/RelaxOn/App/ViewModel/CustomSoundViewModel.swift
+++ b/RelaxOn/App/ViewModel/CustomSoundViewModel.swift
@@ -33,9 +33,6 @@ final class CustomSoundViewModel: ObservableObject {
     let volumeRange: [Float] = stride(from: 0.1, through: 1.0, by: 0.01).map {
         Float(String(format: "%.2f", $0)) ?? 0.0
     }
-
-    // TODO: 필요없음. 없으면 안되는건지 재확인 후 삭제
-    let filterRange: [Float] = stride(from: -50.0, through: 50.0, by: 1.0).map { Float($0) }
     
     /// 각 오디오 필터에 대한 서브 필터를 저장하는 딕셔너리
     let filterDictionary: [SoundCategory: [AudioFilter]] = [

--- a/RelaxOn/App/Views/Components/DragCircularSlider.swift
+++ b/RelaxOn/App/Views/Components/DragCircularSlider.swift
@@ -12,7 +12,7 @@
 
 import SwiftUI
 
-struct CircularSlider: View {
+struct DragCircularSlider: View {
     
     @EnvironmentObject var viewModel: CustomSoundViewModel
     
@@ -35,10 +35,9 @@ struct CircularSlider: View {
     private var width: CGFloat { type.width }
     
     // 슬라이더의 angle값을 반환
-    init(type: CircleType, imageName: String, isOnDrag: Bool, range: [Float], angleChanged: @escaping (Double) -> Void) {
+    init(type: CircleType, imageName: String, range: [Float], angleChanged: @escaping (Double) -> Void) {
         self.type = type
         self.imageName = imageName
-        self.isOnDrag = isOnDrag
         self.angleChanged = angleChanged
         self.minValue = Double(range.first ?? 0)
         self.maxValue = Double(range.last ?? 1)
@@ -56,13 +55,7 @@ struct CircularSlider: View {
             .rotationEffect(rotationAngle - Angle(degrees: 90))
             .gesture(
                 DragGesture(minimumDistance: 0.0)
-                    .onChanged(){ value in
-                        if isOnDrag {
-                            onDrag(value: value.location)
-                        } else {
-                            onMove(value: value.location, isMoved: $isMoved)
-                        }
-                    }
+                    .onChanged(){ value in onDrag(value: value.location) }
             )
             .onAppear {
                 self.rotationAngle = Angle(degrees: progressFraction * 360.0)
@@ -87,50 +80,6 @@ struct CircularSlider: View {
         rotationAngle = Angle(radians: positiveAngle)
     }
     
-    // 이동형 움직임
-    func onMove(value: CGPoint, isMoved: Binding<Bool>) {
-        // 입력 받은 위치로 벡터를 생성합니다. (iOS는 y축이 반대 방향이므로 -y로 설정합니다.)
-        let vector = CGVector(dx: value.x, dy: -value.y)
-        
-        // atan2 함수를 사용하여 벡터의 각도를 계산합니다.
-        let angleRadians = atan2(vector.dx, vector.dy)
-        
-        let positiveAngleRange: CGFloat = 2.0 * .pi
-        
-        // 각도가 음수인 경우를 대비해, 각도를 0 ~ 2π 범위로 맞춥니다.
-        let positiveAngle = angleRadians < 0.0 ? angleRadians + (2.0 * .pi) : angleRadians
-        
-        // 계산된 각도를 이용해서 angle 값을 업데이트합니다.
-        angle = ((positiveAngle /  (2.0 * .pi)) * (maxValue - minValue )) + minValue
-        angleChanged(angle)
-        
-        // snappedAngle을 5칸으로 분류
-        let snappedAngle = round((positiveAngle / positiveAngleRange) * 5.0)
-        let snappedPositiveAngle = (positiveAngleRange / 5.0) * snappedAngle
-        
-        if snappedAngle == 0 {
-            rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle)
-        } else {
-            if isMoved.wrappedValue {
-                withAnimation(.spring(response: 0.5)) { rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle) }
-            } else {
-                isMoved.wrappedValue = true
-                rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle)
-            }
-        }
-        
-        if Int(rotationAngle.radians) != Int(self.angle) {
-            currentFilterIndex = (currentFilterIndex + 1) % viewModel.filters.count
-            DispatchQueue.main.async {
-                viewModel.sound.filter = viewModel.filters[currentFilterIndex]
-                if viewModel.isPlaying {
-                    viewModel.stopSound()
-                }
-                viewModel.play(with: viewModel.sound)
-            }
-        }
-    }
-    
     // 진행률을 계산하는 private 변수입니다.
     private var progressFraction: Double {
         // 진행률은 현재 값에서 최소값을 빼고, 그 결과를 (최대값 - 최소값)으로 나눈 값입니다.
@@ -139,9 +88,9 @@ struct CircularSlider: View {
 
 }
 
-struct preCircularSliderView_Previews: PreviewProvider {
+struct preDragCircularSliderView_Previews: PreviewProvider {
     static var previews: some View {
-        CircularSlider(type: .medium, imageName: "filter", isOnDrag: true, range: [1.0]) { _ in }
+        DragCircularSlider(type: .medium, imageName: "filter", range: [1.0]) { _ in }
             .environmentObject(CustomSoundViewModel())
     }
 }

--- a/RelaxOn/App/Views/Components/SnapCircularSlider.swift
+++ b/RelaxOn/App/Views/Components/SnapCircularSlider.swift
@@ -63,7 +63,8 @@ struct SnapCircularSlider: View {
         // snappedAngle을 5칸으로 분류
         let snappedAngle = round((positiveAngle / positiveAngleRange) * 5.0)
         let snappedPositiveAngle = (positiveAngleRange / 5.0) * snappedAngle
-        print("rotation Angle = \(rotationAngle.radians)")
+        print("rotation Angle = \(snappedAngle)")
+        currentFilterIndex = Int(snappedAngle)
         
         if snappedAngle == 0 {
             rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle)
@@ -78,7 +79,7 @@ struct SnapCircularSlider: View {
     }
     
     func changeFilter() {
-        currentFilterIndex = (currentFilterIndex + 1) % viewModel.filters.count
+        currentFilterIndex = (currentFilterIndex) % viewModel.filters.count
         DispatchQueue.main.async {
             viewModel.sound.filter = viewModel.filters[currentFilterIndex]
             if viewModel.isPlaying {

--- a/RelaxOn/App/Views/Components/SnapCircularSlider.swift
+++ b/RelaxOn/App/Views/Components/SnapCircularSlider.swift
@@ -48,9 +48,9 @@ struct SnapCircularSlider: View {
                 DragGesture(minimumDistance: 0.0)
                     .onChanged(){ value in
                         onMove(value: value.location, isMoved: $isMoved)
+                        changeFilter()
                     }
                 )
-            .onAppear { self.rotationAngle = Angle(degrees: progressFraction * 360.0) }
     }
     func onMove(value: CGPoint, isMoved: Binding<Bool>) {
         // 입력 받은 위치로 벡터를 생성합니다. (iOS는 y축이 반대 방향이므로 -y로 설정합니다.)
@@ -64,12 +64,10 @@ struct SnapCircularSlider: View {
         // 각도가 음수인 경우를 대비해, 각도를 0 ~ 2π 범위로 맞춥니다.
         let positiveAngle = angleRadians < 0.0 ? angleRadians + (2.0 * .pi) : angleRadians
         
-        // 계산된 각도를 이용해서 angle 값을 업데이트합니다.
-        angle = ((positiveAngle /  (2.0 * .pi)) * (maxValue - minValue )) + minValue
-        
         // snappedAngle을 5칸으로 분류
         let snappedAngle = round((positiveAngle / positiveAngleRange) * 5.0)
         let snappedPositiveAngle = (positiveAngleRange / 5.0) * snappedAngle
+        print("rotation Angle = \(rotationAngle.radians)")
         
         if snappedAngle == 0 {
             rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle)
@@ -81,27 +79,16 @@ struct SnapCircularSlider: View {
                 rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle)
             }
         }
-        
-        if Int(rotationAngle.radians) != Int(self.angle) {
-            currentFilterIndex = (currentFilterIndex + 1) % viewModel.filters.count
-            DispatchQueue.main.async {
-                viewModel.sound.filter = viewModel.filters[currentFilterIndex]
-                if viewModel.isPlaying {
-                    viewModel.stopSound()
-                }
-                viewModel.play(with: viewModel.sound)
+    }
+    
+    func changeFilter() {
+        currentFilterIndex = (currentFilterIndex + 1) % viewModel.filters.count
+        DispatchQueue.main.async {
+            viewModel.sound.filter = viewModel.filters[currentFilterIndex]
+            if viewModel.isPlaying {
+                viewModel.stopSound()
             }
+            viewModel.play(with: viewModel.sound)
         }
     }
-    // 진행률을 계산하는 private 변수입니다.
-    private var progressFraction: Double {
-        // 진행률은 현재 값에서 최소값을 빼고, 그 결과를 (최대값 - 최소값)으로 나눈 값입니다.
-        return ((angle - minValue) / (maxValue - minValue))
-    }
 }
-
-//struct SnapCircularSlider_Previews: PreviewProvider {
-//    static var previews: some View {
-//        SnapCircularSlider()
-//    }
-//}

--- a/RelaxOn/App/Views/Components/SnapCircularSlider.swift
+++ b/RelaxOn/App/Views/Components/SnapCircularSlider.swift
@@ -21,7 +21,6 @@ struct SnapCircularSlider: View {
     @State private var rotationAngle = Angle(degrees: 0)
     
     var imageName: String
-    var angleChanged: (Double) -> Void
     @State var isMoved: Bool = false
     
     private var minValue = 0.0
@@ -29,10 +28,9 @@ struct SnapCircularSlider: View {
     private var width: CGFloat { type.width }
     
     // 슬라이더의 angle값을 반환
-    init(type: CircleType, imageName: String, range: [Float], angleChanged: @escaping (Double) -> Void) {
+    init(type: CircleType, imageName: String, range: [Float]) {
         self.type = type
         self.imageName = imageName
-        self.angleChanged = angleChanged
         self.minValue = Double(range.first ?? 0)
         self.maxValue = Double(range.last ?? 1)
     }
@@ -68,7 +66,6 @@ struct SnapCircularSlider: View {
         
         // 계산된 각도를 이용해서 angle 값을 업데이트합니다.
         angle = ((positiveAngle /  (2.0 * .pi)) * (maxValue - minValue )) + minValue
-        angleChanged(angle)
         
         // snappedAngle을 5칸으로 분류
         let snappedAngle = round((positiveAngle / positiveAngleRange) * 5.0)

--- a/RelaxOn/App/Views/Components/SnapCircularSlider.swift
+++ b/RelaxOn/App/Views/Components/SnapCircularSlider.swift
@@ -8,13 +8,103 @@
 import SwiftUI
 
 struct SnapCircularSlider: View {
+    
+    @EnvironmentObject var viewModel: CustomSoundViewModel
+    
+    @State var type: CircleType
+    @State private var currentFilterIndex = 0
+    
+    /// 회전각도 관련 속성
+    @State var angle: Double = Double.random(in: 0...360)
+    
+    /// 이미지의 위치와 방향을 정하는 속성
+    @State private var rotationAngle = Angle(degrees: 0)
+    
+    var imageName: String
+    var angleChanged: (Double) -> Void
+    @State var isMoved: Bool = false
+    
+    private var minValue = 0.0
+    private var maxValue = 1.0
+    private var width: CGFloat { type.width }
+    
+    // 슬라이더의 angle값을 반환
+    init(type: CircleType, imageName: String, range: [Float], angleChanged: @escaping (Double) -> Void) {
+        self.type = type
+        self.imageName = imageName
+        self.angleChanged = angleChanged
+        self.minValue = Double(range.first ?? 0)
+        self.maxValue = Double(range.last ?? 1)
+    }
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Image(imageName)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 24)
+        // FIXME: rotationAngle이 +90이 되는 현상
+            .rotationEffect(-rotationAngle + Angle(degrees: 90))
+            .offset(x: width / 2)
+            .rotationEffect(rotationAngle - Angle(degrees: 90))
+            .gesture(
+                DragGesture(minimumDistance: 0.0)
+                    .onChanged(){ value in
+                        onMove(value: value.location, isMoved: $isMoved)
+                    }
+                )
+            .onAppear { self.rotationAngle = Angle(degrees: progressFraction * 360.0) }
+    }
+    func onMove(value: CGPoint, isMoved: Binding<Bool>) {
+        // 입력 받은 위치로 벡터를 생성합니다. (iOS는 y축이 반대 방향이므로 -y로 설정합니다.)
+        let vector = CGVector(dx: value.x, dy: -value.y)
+        
+        // atan2 함수를 사용하여 벡터의 각도를 계산합니다.
+        let angleRadians = atan2(vector.dx, vector.dy)
+        
+        let positiveAngleRange: CGFloat = 2.0 * .pi
+        
+        // 각도가 음수인 경우를 대비해, 각도를 0 ~ 2π 범위로 맞춥니다.
+        let positiveAngle = angleRadians < 0.0 ? angleRadians + (2.0 * .pi) : angleRadians
+        
+        // 계산된 각도를 이용해서 angle 값을 업데이트합니다.
+        angle = ((positiveAngle /  (2.0 * .pi)) * (maxValue - minValue )) + minValue
+        angleChanged(angle)
+        
+        // snappedAngle을 5칸으로 분류
+        let snappedAngle = round((positiveAngle / positiveAngleRange) * 5.0)
+        let snappedPositiveAngle = (positiveAngleRange / 5.0) * snappedAngle
+        
+        if snappedAngle == 0 {
+            rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle)
+        } else {
+            if isMoved.wrappedValue {
+                withAnimation(.spring(response: 0.5)) { rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle) }
+            } else {
+                isMoved.wrappedValue = true
+                rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle)
+            }
+        }
+        
+        if Int(rotationAngle.radians) != Int(self.angle) {
+            currentFilterIndex = (currentFilterIndex + 1) % viewModel.filters.count
+            DispatchQueue.main.async {
+                viewModel.sound.filter = viewModel.filters[currentFilterIndex]
+                if viewModel.isPlaying {
+                    viewModel.stopSound()
+                }
+                viewModel.play(with: viewModel.sound)
+            }
+        }
+    }
+    // 진행률을 계산하는 private 변수입니다.
+    private var progressFraction: Double {
+        // 진행률은 현재 값에서 최소값을 빼고, 그 결과를 (최대값 - 최소값)으로 나눈 값입니다.
+        return ((angle - minValue) / (maxValue - minValue))
     }
 }
 
-struct SnapCircularSlider_Previews: PreviewProvider {
-    static var previews: some View {
-        SnapCircularSlider()
-    }
-}
+//struct SnapCircularSlider_Previews: PreviewProvider {
+//    static var previews: some View {
+//        SnapCircularSlider()
+//    }
+//}

--- a/RelaxOn/App/Views/Components/SnapCircularSlider.swift
+++ b/RelaxOn/App/Views/Components/SnapCircularSlider.swift
@@ -1,0 +1,20 @@
+//
+//  SnapCircularSlider.swift
+//  RelaxOn
+//
+//  Created by 황석현 on 2023/06/15.
+//
+
+import SwiftUI
+
+struct SnapCircularSlider: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct SnapCircularSlider_Previews: PreviewProvider {
+    static var previews: some View {
+        SnapCircularSlider()
+    }
+}

--- a/RelaxOn/App/Views/Components/SnapCircularSlider.swift
+++ b/RelaxOn/App/Views/Components/SnapCircularSlider.swift
@@ -23,16 +23,12 @@ struct SnapCircularSlider: View {
     var imageName: String
     @State var isMoved: Bool = false
     
-    private var minValue = 0.0
-    private var maxValue = 1.0
     private var width: CGFloat { type.width }
     
     // 슬라이더의 angle값을 반환
-    init(type: CircleType, imageName: String, range: [Float]) {
+    init(type: CircleType, imageName: String) {
         self.type = type
         self.imageName = imageName
-        self.minValue = Double(range.first ?? 0)
-        self.maxValue = Double(range.last ?? 1)
     }
     
     var body: some View {

--- a/RelaxOn/App/Views/Components/SnapCircularSlider.swift
+++ b/RelaxOn/App/Views/Components/SnapCircularSlider.swift
@@ -63,7 +63,6 @@ struct SnapCircularSlider: View {
         // snappedAngle을 5칸으로 분류
         let snappedAngle = round((positiveAngle / positiveAngleRange) * 5.0)
         let snappedPositiveAngle = (positiveAngleRange / 5.0) * snappedAngle
-        print("rotation Angle = \(snappedAngle)")
         currentFilterIndex = Int(snappedAngle)
         
         if snappedAngle == 0 {

--- a/RelaxOn/App/Views/Components/SnapCircularSlider.swift
+++ b/RelaxOn/App/Views/Components/SnapCircularSlider.swift
@@ -63,16 +63,22 @@ struct SnapCircularSlider: View {
         // snappedAngle을 5칸으로 분류
         let snappedAngle = round((positiveAngle / positiveAngleRange) * 5.0)
         let snappedPositiveAngle = (positiveAngleRange / 5.0) * snappedAngle
-        currentFilterIndex = Int(snappedAngle)
         
-        if snappedAngle == 0 {
-            rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle)
+        currentFilterIndex = Int(snappedAngle) % 5
+        let angleDifference = positiveAngle - snappedPositiveAngle
+        let adjustedAngle = snappedPositiveAngle + (angleDifference * 0.2)
+        
+        if snappedAngle == 0 && !isMoved.wrappedValue{
+            rotationAngle = -Angle(radians: -adjustedAngle)
+            print("rotationAngle = \(rotationAngle)")
+            isMoved.wrappedValue = true
         } else {
             if isMoved.wrappedValue {
-                withAnimation(.spring(response: 0.5)) { rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle) }
+                        rotationAngle = -Angle(radians: -adjustedAngle)
+                        print("rotationAngle = \(rotationAngle)")
             } else {
-                isMoved.wrappedValue = true
-                rotationAngle = -Angle(radians: positiveAngleRange - snappedPositiveAngle)
+                rotationAngle = -Angle(radians: -adjustedAngle)
+                print("rotationAngle = \(rotationAngle)")
             }
         }
     }

--- a/RelaxOn/App/Views/Home/SoundDetailView.swift
+++ b/RelaxOn/App/Views/Home/SoundDetailView.swift
@@ -102,13 +102,13 @@ struct SoundDetailView: View {
     func soundController() -> some View {
         ZStack {
             backgroundCircle()
-            CircularSlider(type: .xSmall, imageName: featureIcon[0], isOnDrag: true, range: viewModel.intervalRange) { angle in
+            DragCircularSlider(type: .xSmall, imageName: featureIcon[0], range: viewModel.intervalRange) { angle in
                 viewModel.interval = Float(angle)
             }
-            CircularSlider(type: .small, imageName: featureIcon[1], isOnDrag: true, range: viewModel.volumeRange) { angle in
+            DragCircularSlider(type: .small, imageName: featureIcon[1], range: viewModel.volumeRange) { angle in
                 viewModel.volume = Float(angle)
             }
-            CircularSlider(type: .medium, imageName: featureIcon[2], isOnDrag: true, range: viewModel.pitchRange) { angle in
+            DragCircularSlider(type: .medium, imageName: featureIcon[2], range: viewModel.pitchRange) { angle in
                 viewModel.pitch = Float(angle)
             }
             SnapCircularSlider(type: .large, imageName: featureIcon[3], range: viewModel.filterRange) { angle in }

--- a/RelaxOn/App/Views/Home/SoundDetailView.swift
+++ b/RelaxOn/App/Views/Home/SoundDetailView.swift
@@ -111,8 +111,7 @@ struct SoundDetailView: View {
             CircularSlider(type: .medium, imageName: featureIcon[2], isOnDrag: true, range: viewModel.pitchRange) { angle in
                 viewModel.pitch = Float(angle)
             }
-            CircularSlider(type: .large, imageName: featureIcon[3], isOnDrag: false, range: viewModel.filterRange) { angle in
-            }
+            SnapCircularSlider(type: .large, imageName: featureIcon[3], range: viewModel.filterRange) { angle in }
         }
         .padding(24)
     }

--- a/RelaxOn/App/Views/Home/SoundDetailView.swift
+++ b/RelaxOn/App/Views/Home/SoundDetailView.swift
@@ -111,7 +111,7 @@ struct SoundDetailView: View {
             DragCircularSlider(type: .medium, imageName: featureIcon[2], range: viewModel.pitchRange) { angle in
                 viewModel.pitch = Float(angle)
             }
-            SnapCircularSlider(type: .large, imageName: featureIcon[3], range: viewModel.filterRange)
+            SnapCircularSlider(type: .large, imageName: featureIcon[3])
         }
         .padding(24)
     }

--- a/RelaxOn/App/Views/Home/SoundDetailView.swift
+++ b/RelaxOn/App/Views/Home/SoundDetailView.swift
@@ -111,7 +111,7 @@ struct SoundDetailView: View {
             DragCircularSlider(type: .medium, imageName: featureIcon[2], range: viewModel.pitchRange) { angle in
                 viewModel.pitch = Float(angle)
             }
-            SnapCircularSlider(type: .large, imageName: featureIcon[3], range: viewModel.filterRange) { angle in }
+            SnapCircularSlider(type: .large, imageName: featureIcon[3], range: viewModel.filterRange)
         }
         .padding(24)
     }


### PR DESCRIPTION
## 작업 내용 (Content)
### CircularSlider를 Drag/Snap으로 분리하였습니다.
  - Drag : 볼륨, 주기, 음높이 조절
  - Snap : 필터 전환

### FiterRange를 삭제하였습니다
  - 코드를 살펴본 결과 Filter기능에는 Range의 개념이 없으므로 이를 삭제하였습니다.

### 필터가 전환되는 로직을 수정하였습니다.
  - 기존 로직은 이동할 때마다 currnetFilterIndex에 +1을 하여 필터를 교체하였습니다.
  - 슬라이더의 위치에 따라 0~4의 값을 가지는 snappedAngle를 currentFiterIndex에 대입하여 필터를 교체합니다.
  - 즉, 슬라이더의 위치에 따라서 해당 필터가 재생되게끔 구현하였습니다.

### 슬라이더가 이동하는 애니메이션을 보완하였습니다.
  - 12시 방향에서 좌우 이동하면 슬라이더가 전체회전을 하는 현상이 있었으나 이를 개선하였습니다.

## 기타 사항 (Etc)
- 필터에 대한 로직을 수정하기 전에 앱이 꺼지는 현상이 있었는데 수정 후 해당 현상이 사라졌습니다.
- 추가적으로 불필요한 코드를 확인하여 삭제, 수정하였습니다.
- 필터를 전환하는 기능은 정상 작동합니다!

## 관련 사진(Optional)
![Simulator Screen Recording - iPhone 14 Pro - 2023-06-21 at 02 06 09](https://github.com/M1zz/RelaxOn/assets/109560875/489af96b-1df0-408e-98ac-308e1843b44b)
