### PR TITLE
🐛[Fix]: SoundDetail뷰의 지표 위치 고정

### DIFF
--- a/RelaxOn/App/Views/Components/DragCircularSlider.swift
+++ b/RelaxOn/App/Views/Components/DragCircularSlider.swift
@@ -20,7 +20,7 @@ struct DragCircularSlider: View {
     @State private var currentFilterIndex = 0
     
     /// 회전각도 관련 속성
-    @State var angle: Double = Double.random(in: 0...360)
+    @State var angle: Double = 0.0
     
     /// 이미지의 위치와 방향을 정하는 속성
     @State private var rotationAngle = Angle(degrees: 0)

--- a/RelaxOn/App/Views/Components/SnapCircularSlider.swift
+++ b/RelaxOn/App/Views/Components/SnapCircularSlider.swift
@@ -14,9 +14,6 @@ struct SnapCircularSlider: View {
     @State var type: CircleType
     @State private var currentFilterIndex = 0
     
-    /// 회전각도 관련 속성
-    @State var angle: Double = Double.random(in: 0...360)
-    
     /// 이미지의 위치와 방향을 정하는 속성
     @State private var rotationAngle = Angle(degrees: 0)
     


### PR DESCRIPTION
## 작업 내용 (Content)
- SoundDetailView 내의 지표들의 위치를 고정하였습니다.
![image](https://github.com/M1zz/RelaxOn/assets/109560875/83190315-4e30-4681-83ce-c583aee0b3b5)
  - Double.random(in:...) 사용해 화면이 나올 때마다 위치가 랜덤으로 지정되었으나 이를 0으로 고정시킴으로써
  지표들의 위치는 매번 똑같이 표시됩니다.


## 기타 사항 (Etc)
- 지표들의 위치가 다른 것은 각 지표가 가진 범위값이 다르기 때문입니다. 
따라서 모든 지표의 위치값은 0이지만 각 범위마다 0의 위치가 다르기에 이와 같이 표시됩니다.
- 지표의 위치를 정렬시킬까 고민하다가 오히려 지금과 같은 위치가 사용자가 움직이고 싶게 만들 것 같아서 
PM(승우님)과 소통 후 작업 마무리 하였습니다.

## Close Issues
Close #444 

## 관련 사진(Optional)
![image](https://github.com/M1zz/RelaxOn/assets/109560875/fd3eb2b5-95f3-4b24-aa3d-2ec62440f0d9)
