### PR TITLE
🐛[Fix]: #446-타이머 리셋 이슈

### DIFF
--- a/RelaxOn/App/Manager/TimerManager.swift
+++ b/RelaxOn/App/Manager/TimerManager.swift
@@ -101,7 +101,7 @@ class TimerManager: ObservableObject {
         }
     }
     // 타이머 시간 뷰
-    func getTimeText(timerManager: TimerManager) -> some View {
+    func getTimeText() -> some View {
         if remainingSeconds > 3599 {
             return AnyView (
                 Text(String(format: "%02d:%02d:%02d", max(self.remainingSeconds / 3600, 0), max((self.remainingSeconds % 3600) / 60, 0), max(self.remainingSeconds % 60, 0)))
@@ -131,7 +131,7 @@ class TimerManager: ObservableObject {
         }
     }
     // 타이머 원형바 뷰
-    func getCircularProgressBar(timerManager: TimerManager) -> some View {
+    func getCircularProgressBar() -> some View {
         ZStack {
             Circle()
                 .stroke(lineWidth: 7)

--- a/RelaxOn/App/Manager/TimerManager.swift
+++ b/RelaxOn/App/Manager/TimerManager.swift
@@ -109,7 +109,7 @@ class TimerManager: ObservableObject {
                     .padding()
                     .font(.system(size: 50, weight: .light))
                     .onAppear {
-                        if (self.remainingSeconds == 0) {
+                        if self.remainingSeconds == 0 {
                             self.startTimer(timerManager: self)
                         }
                     }
@@ -122,7 +122,7 @@ class TimerManager: ObservableObject {
                     .padding()
                     .font(.system(size: 60, weight: .light))
                     .onAppear {
-                        if (self.remainingSeconds == 0) {
+                        if self.remainingSeconds == 0 {
                             self.startTimer(timerManager: self)
                         }
                     }
@@ -144,7 +144,7 @@ class TimerManager: ObservableObject {
                 .foregroundColor(Color(.TimerMyListBackground))
                 .rotationEffect(Angle(degrees: 270.0))
                 .onAppear {
-                    if (self.remainingSeconds == 0) {
+                    if self.remainingSeconds == 0 {
                         self.startTimeprogressBar(timerManager: self)
                     }
                 }

--- a/RelaxOn/App/Manager/TimerManager.swift
+++ b/RelaxOn/App/Manager/TimerManager.swift
@@ -109,7 +109,9 @@ class TimerManager: ObservableObject {
                     .padding()
                     .font(.system(size: 50, weight: .light))
                     .onAppear {
-                        timerManager.startTimer(timerManager: timerManager)
+                        if (timerManager.remainingSeconds == 0) {
+                            timerManager.startTimer(timerManager: timerManager)
+                        }
                     }
                     .onDisappear { }
             )
@@ -120,7 +122,9 @@ class TimerManager: ObservableObject {
                     .padding()
                     .font(.system(size: 60, weight: .light))
                     .onAppear {
-                        timerManager.startTimer(timerManager: timerManager)
+                        if (timerManager.remainingSeconds == 0) {
+                            timerManager.startTimer(timerManager: timerManager)
+                        }
                     }
                     .onDisappear { }
             )
@@ -140,7 +144,9 @@ class TimerManager: ObservableObject {
                 .foregroundColor(Color(.TimerMyListBackground))
                 .rotationEffect(Angle(degrees: 270.0))
                 .onAppear {
-                    timerManager.startTimeprogressBar(timerManager: timerManager)
+                    if (timerManager.remainingSeconds == 0) {
+                        timerManager.startTimeprogressBar(timerManager: timerManager)
+                    }
                 }
                 .onDisappear { }
         }

--- a/RelaxOn/App/Manager/TimerManager.swift
+++ b/RelaxOn/App/Manager/TimerManager.swift
@@ -111,9 +111,8 @@ class TimerManager: ObservableObject {
                     .onAppear {
                         timerManager.startTimer(timerManager: timerManager)
                     }
-                    .onDisappear {
-                        timerManager.stopTimer(timerManager: timerManager)
-                    })
+                    .onDisappear { }
+            )
         } else {
             return AnyView (
                 Text(String(format: "%02d:%02d", max((timerManager.remainingSeconds % 3600) / 60, 0), max(timerManager.remainingSeconds % 60, 0)))
@@ -123,9 +122,8 @@ class TimerManager: ObservableObject {
                     .onAppear {
                         timerManager.startTimer(timerManager: timerManager)
                     }
-                    .onDisappear {
-                        timerManager.stopTimer(timerManager: timerManager)
-                    })
+                    .onDisappear { }
+            )
         }
     }
     // 타이머 원형바 뷰
@@ -144,9 +142,7 @@ class TimerManager: ObservableObject {
                 .onAppear {
                     timerManager.startTimeprogressBar(timerManager: timerManager)
                 }
-                .onDisappear {
-                    timerManager.stopTimer(timerManager: timerManager)
-                }
+                .onDisappear { }
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 20)

--- a/RelaxOn/App/Manager/TimerManager.swift
+++ b/RelaxOn/App/Manager/TimerManager.swift
@@ -29,14 +29,14 @@ class TimerManager: ObservableObject {
     
     // 타이머객체 실행
     func startTimer(timerManager: TimerManager) {
-        timerManager.remainingSeconds = getTime(timerManager: timerManager)
+        self.remainingSeconds = getTime(timerManager: self)
         
-        timerManager.textTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
-            timerManager.remainingSeconds -= 1
+        self.textTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
+            self.remainingSeconds -= 1
             
-            if timerManager.remainingSeconds <= 0 {
+            if self.remainingSeconds <= 0 {
                 timer.invalidate()
-                timerManager.remainingSeconds = 0
+                self.remainingSeconds = 0
                 self.viewModel?.stopSound()
                 self.timerDidFinish?()
             }
@@ -44,8 +44,8 @@ class TimerManager: ObservableObject {
     }
     // 설정한 시간을 초로 변환
     func getTime(timerManager: TimerManager) -> Int {
-        var hour = timerManager.selectedTimeIndexHours
-        var minute = timerManager.selectedTimeIndexMinutes
+        var hour = self.selectedTimeIndexHours
+        var minute = self.selectedTimeIndexMinutes
         
         hour = hour * 3600
         minute = minute * 60
@@ -54,47 +54,47 @@ class TimerManager: ObservableObject {
     }
     // 타이머 중지
     func stopTimer(timerManager: TimerManager) {
-        timerManager.textTimer?.invalidate()
-        timerManager.progressTimer?.invalidate()
-        timerManager.remainingSeconds = 0
-        timerManager.progress = 1.0
+        self.textTimer?.invalidate()
+        self.progressTimer?.invalidate()
+        self.remainingSeconds = 0
+        self.progress = 1.0
         self.viewModel?.stopSound()
     }
     
     func pauseTimer(timerManager: TimerManager) {
-        timerManager.textTimer?.invalidate()
-        timerManager.textTimer = nil
-        timerManager.progressTimer?.invalidate()
-        timerManager.progressTimer = nil
+        self.textTimer?.invalidate()
+        self.textTimer = nil
+        self.progressTimer?.invalidate()
+        self.progressTimer = nil
         self.viewModel?.stopSound()
     }
     
     // 타이머 재개
     func resumeTimer(timerManager: TimerManager) {
-        timerManager.textTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
-            timerManager.remainingSeconds -= 1
+        self.textTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
+            self.remainingSeconds -= 1
             
-            if timerManager.remainingSeconds <= 0 {
+            if self.remainingSeconds <= 0 {
                 timer.invalidate()
-                timerManager.remainingSeconds = 0
+                self.remainingSeconds = 0
                 self.viewModel?.stopSound()
                 self.timerDidFinish?()
             }
         }
-        startTimeprogressBar(timerManager: timerManager)
+        startTimeprogressBar(timerManager: self)
     }
     
     // 타이머 진행바 실행
     func startTimeprogressBar(timerManager: TimerManager) {
-        let settingTime: Double = Double(timerManager.getTime(timerManager: timerManager))
+        let settingTime: Double = Double(self.getTime(timerManager: self))
         var secondPercentage: Double = 0
         secondPercentage = Double((1 / settingTime) * 1.0)
         
-        timerManager.progressTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
-            timerManager.progress -= secondPercentage
-            if timerManager.progress <= 0 {
+        self.progressTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
+            self.progress -= secondPercentage
+            if self.progress <= 0 {
                 timer.invalidate()
-                timerManager.progress = 1.0
+                self.progress = 1.0
                 self.viewModel?.stopSound()
                 self.timerDidFinish?()
             }
@@ -104,26 +104,26 @@ class TimerManager: ObservableObject {
     func getTimeText(timerManager: TimerManager) -> some View {
         if remainingSeconds > 3599 {
             return AnyView (
-                Text(String(format: "%02d:%02d:%02d", max(timerManager.remainingSeconds / 3600, 0), max((timerManager.remainingSeconds % 3600) / 60, 0), max(timerManager.remainingSeconds % 60, 0)))
+                Text(String(format: "%02d:%02d:%02d", max(self.remainingSeconds / 3600, 0), max((self.remainingSeconds % 3600) / 60, 0), max(self.remainingSeconds % 60, 0)))
                     .frame(maxWidth: .infinity)
                     .padding()
                     .font(.system(size: 50, weight: .light))
                     .onAppear {
-                        if (timerManager.remainingSeconds == 0) {
-                            timerManager.startTimer(timerManager: timerManager)
+                        if (self.remainingSeconds == 0) {
+                            self.startTimer(timerManager: self)
                         }
                     }
                     .onDisappear { }
             )
         } else {
             return AnyView (
-                Text(String(format: "%02d:%02d", max((timerManager.remainingSeconds % 3600) / 60, 0), max(timerManager.remainingSeconds % 60, 0)))
+                Text(String(format: "%02d:%02d", max((self.remainingSeconds % 3600) / 60, 0), max(self.remainingSeconds % 60, 0)))
                     .frame(maxWidth: .infinity)
                     .padding()
                     .font(.system(size: 60, weight: .light))
                     .onAppear {
-                        if (timerManager.remainingSeconds == 0) {
-                            timerManager.startTimer(timerManager: timerManager)
+                        if (self.remainingSeconds == 0) {
+                            self.startTimer(timerManager: self)
                         }
                     }
                     .onDisappear { }
@@ -139,13 +139,13 @@ class TimerManager: ObservableObject {
                 .foregroundColor(.gray)
             
             Circle()
-                .trim(from: 0.0, to: CGFloat(min(timerManager.progress, 1.0)))
+                .trim(from: 0.0, to: CGFloat(min(self.progress, 1.0)))
                 .stroke(style: StrokeStyle(lineWidth: 7, lineCap: .round, lineJoin: .round))
                 .foregroundColor(Color(.TimerMyListBackground))
                 .rotationEffect(Angle(degrees: 270.0))
                 .onAppear {
-                    if (timerManager.remainingSeconds == 0) {
-                        timerManager.startTimeprogressBar(timerManager: timerManager)
+                    if (self.remainingSeconds == 0) {
+                        self.startTimeprogressBar(timerManager: self)
                     }
                 }
                 .onDisappear { }

--- a/RelaxOn/App/Views/Timer/TimerProgressView.swift
+++ b/RelaxOn/App/Views/Timer/TimerProgressView.swift
@@ -16,8 +16,8 @@ struct TimerProgressView: View {
     
     var body: some View {
         ZStack {
-            timerManager.getCircularProgressBar(timerManager: timerManager)
-            timerManager.getTimeText(timerManager: timerManager)
+            timerManager.getCircularProgressBar()
+            timerManager.getTimeText()
         }
         .frame(maxWidth: .infinity)
         .padding(20)


### PR DESCRIPTION
## 작업 내용 (Content)
- 타이머를 실행하고 화면이동하면 타이머가 리셋되는 현상을 수정하였습니다. 
![image](https://github.com/M1zz/RelaxOn/assets/109560875/cc9d2686-0269-4edd-9eb4-93acfd8868ec)
- onAppear과 onDisappear의 적용 시킬 때 사용자의 행동을 예측하지 않아 
화면의 변화에 따라서 Timer가 작동했었습니다.
### onDisappear
화면이 사라짐이 곧 타이머의 종료와 연관되어 있지 않으므로 Action을 비웠습니다.
그리고 onDisappear을 아예 삭제해버리니 앱이 꺼지는 현상이 있었습니다.
이는 제가 이해한 바에 따르면 화면이 사라졌을 때의 조건이 사라짐으로 메모리 누수현상을 방지하고자 Xcode가 
앱을 중단시키지 않았나 생각합니다.
### onAppear
화면이 표시될 때마다 startTimer를 실행함으로써 Timer인스턴스가 중복됨을 확인했습니다.(시간이 2초씩 감소)
그래서 remainingSeconds를 활용하여 타이머가 비활성화임을 확인하고 startTimer함수를 호출하게 수정하였습니다.
### 시뮬레이터 꺼짐 당시 에러코드
```Thread 1: EXC_BREAKPOINT (code=1, subcode=0x10a65c2cc)```



## 기타 사항 (Etc)
- 전반적으로 타이머 관련 코드들의 정리가 필요해보입니다. 이는 추후에 보완해보겠습니다.

## Close Issues
Close #446 

## 관련 사진(Optional)
![Simulator Screen Recording - iPhone 14 Pro - 2023-08-02 at 00 14 12](https://github.com/M1zz/RelaxOn/assets/109560875/e7efe4ce-24f1-47e3-800e-739ca818fedc)
