### PR TITLE
🐛 [Fix]:  소리 선택창에서 자동재생되는 오류

### DIFF
--- a/RelaxOn/App/Views/Timer/TimerSoundSelectModalView.swift
+++ b/RelaxOn/App/Views/Timer/TimerSoundSelectModalView.swift
@@ -28,8 +28,6 @@ struct TimerSoundSelectModalView: View {
                         if viewModel.isPlaying {
                             viewModel.stopSound()
                             viewModel.play(with: viewModel.sound)
-                        } else {
-                            viewModel.play(with: viewModel.sound)
                         }
                         presentationMode.wrappedValue.dismiss()
                     }) {


### PR DESCRIPTION
## 오류 설명
### 오류 발생 위치 : 타이머뷰의 소리 선택창(모달 뷰)
* 모달 뷰에서 소리를 선택하고 완료를 누르면 소리가 자동 재생된다.
* 저장된 소리가 없어도 모달 뷰에서 완료를 누르면 소리가 자동 재생된다.(WaterDrop 재생됨)

### -> 원치 않은 상황에서 소리가 재생되는 현상 해결

## 작업 내용 (Content)
- TimerSoundSelectModalView에서 완료버튼 조건문을 수정
  - 모달뷰의 완료버튼을 누르면 재생하는 메서드가 실행됨
  - TimerMainView에서 Start버튼을 누르면 play 메서드가 작동하기 때문에
  중복되는 코드 & 불필요한 작동 으로 판단하여 삭제

## 기타 사항 (Etc)
- 해당 코드를 삭제하면 오류가 해결되는 것처럼 보이는데 코드 작성자(비비)의 의도를 모르는 상태에서 수정하면
추후에 또 다른 오류를 불러일으키진 않을지 고민을 해봤습니다.
- 비비와 소통 후 어떤 상황에 대응하기 위한 의도를 파악하고 오류를 불러일으킬 소지가 없을 것 같다는 판단 하에
PR을 작성하였습니다.


## Close Issues
Close #457 