### PR TITLE
🎨[Design]: Cell Underline 위치 수정

### DIFF
--- a/RelaxOn/App/Views/Listen/ListenListCell.swift
+++ b/RelaxOn/App/Views/Listen/ListenListCell.swift
@@ -36,6 +36,7 @@ struct ListenListCell: View {
                 .foregroundColor(Color(.ListenListCellUnderLine))
                 .padding(.vertical, 2)
                 .background(Color(.DefaultBackground))
+                .offset(y: 12)
         }
         .background(Color(.DefaultBackground))
     }


### PR DESCRIPTION
## 작업 내용 (Content)

offset으로 Uderline 위치 하단으로 이동시켰습니다.

```swift
// 전
Rectangle()
    .frame(height: 1)
    .foregroundColor(Color(.ListenListCellUnderLine))
    .padding(.vertical, 2)
    .background(Color(.DefaultBackground))
```

```swift
// 후
Rectangle()
    .frame(height: 1)
    .foregroundColor(Color(.ListenListCellUnderLine))
    .padding(.vertical, 2)
    .background(Color(.DefaultBackground))
    .offset(y: 12) // 추가
```

## 기타 사항 (Etc)
> 현재 List 를 이용했기 때문에 onDelete로 자동생성되는 삭제버튼을 커스텀하기 어려워 필요하다면 다음 디자인 개선때에는 List를 커스텀 버티컬 스크롤뷰로 구성하면 좋겠다는 생각을 했습니다.

## Close Issues
- 이슈로 등록할 정도는 아니라고 판단하여 따로 생성하진 않았습니다.

## 관련 사진(Optional)
