### PR TITLE
🐛 [Fix]: 검색 기능 수정

### DIFF
--- a/RelaxOn/App/Views/Components/SearchBar.swift
+++ b/RelaxOn/App/Views/Components/SearchBar.swift
@@ -17,58 +17,48 @@ struct SearchBar: View {
     var body: some View {
         HStack {
             Image(systemName: "magnifyingglass")
-                .foregroundColor(Color(.SearchBarText))
-                .padding(.horizontal, 6)
-            
-            if isEditing {
-                TextField("", text: $text)
-                    .font(.system(size: 14, weight: .regular))
-                    .foregroundColor(Color(.SearchBarText))
-                    .layoutPriority(1)
-                    .textFieldStyle(.plain)
-                    .transition(.opacity)
+                .foregroundColor(
+                    text.isEmpty ?
+                    Color(.SearchBarText) : Color(.SearchBarText))
 
-            } else {
-                Button(action: {
-                    withAnimation {
-                        isEditing.toggle()
-                    }
-                }) {
-                    HStack {
-                        Text("저장한 나만의 소리를 검색해보세요")
-                            .font(.system(size: 14))
-                            .foregroundColor(Color(.SearchBarText))
-                            .frame(minHeight: 40)
-                        
-                        Spacer()
-                    }
-                }
-                .transition(.opacity)
-                .frame(maxWidth: .infinity)
-            }
-            
-            if !text.isEmpty {
-                Button(action: {
-                    text = ""
-                    withAnimation {
-                        isEditing.toggle()
-                    }
-                }) {
+            TextField("저장한 나만의 소리를 검색해보세요", text: $text)
+                .autocorrectionDisabled(true)
+                .foregroundColor(Color(.SearchBarText))
+                .overlay(
                     Image(systemName: "xmark.circle.fill")
+                        .padding()
+                        .offset(x: 10)
                         .foregroundColor(Color(.SearchBarText))
-                }
-            }
+                        .opacity(text.isEmpty ? 0.0 : 1.0)
+                        .onTapGesture {
+                            text = ""
+                            UIApplication.shared.endEditing()
+                        }
+                    , alignment: .trailing
+                )
         }
+        .font(.system(size: 14))
         .frame(minHeight: 40)
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
-        .background(Color(.SearchBarBackground))
-        .cornerRadius(8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(.SearchBarBackground))
+        )
     }
 }
+
 
 struct SearchBarView_Previews: PreviewProvider {
     static var previews: some View {
         SearchBar(text: .constant("저장한 나만의 소리를 검색해보세요"))
+    }
+}
+
+import UIKit
+
+extension UIApplication {
+    func endEditing() {
+        sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
### 1. 검색 바 한번 터치시 placeholder 만 사라지는 현상 수정
- `as-is` 저장한 나만의 소리를 검색해보세요 -> 한번 누르면 문구만 사라지고 키보드가 올라오지 않음 -> 한번더 누르면 키보드가 올라옴
- `to-be` 한번 눌렀을 때 바로 키보드 올라오기


```swift
TextField("저장한 나만의 소리를 검색해보세요", text: $text)
    .autocorrectionDisabled(true)
    .foregroundColor(Color(.SearchBarText))
```

이 코드는 SwiftUI에서 TextField를 정의하고 있으며, text 라는 @Binding 변수와 함께 사용됩니다. 터치가 발생하면 플레이스홀더가 사라지고 키보드가 올라오게 됩니다. `.autocorrectionDisabled(true)`를 사용하여 자동 완성 기능을 비활성화했습니다.

---

### 2. 빈 텍스트 검색 후 placeholder 다시 보여주기
- `as-is` 아무 내용도 입력하지 않고 검색창 return 하면 문구 사라진 채로 검색 바 유지됨
- `to-be` 아무 내용도 입력하지 않고 검색창 return 하면 “저장한 나만의 소리를 검색해보세요” 문구 재활성화

```swift
Image(systemName: "xmark.circle.fill")
    .padding()
    .offset(x: 10)
    .foregroundColor(Color(.SearchBarText))
    .opacity(text.isEmpty ? 0.0 : 1.0)
    .onTapGesture {
        text = ""
        UIApplication.shared.endEditing()
    }
```

이 코드는 텍스트 필드에 입력된 텍스트가 있을 경우 스택 뷰에서 오버레이 되는 "xmark.circle.fill" 이미지를 정의합니다. 텍스트 필드가 비어있지 않다면(즉, 텍스트가 있으면) 이미지가 1.0의 불투명도로 표시되고, 비어있으면 0.0의 불투명도로 표시되어 자연스럽게 보이지 않게 됩니다. 이미지에 onTapGesture를 추가하여 사용자가 이미지를 터치하면 텍스트 필드의 텍스트를 초기화하고 키보드가 내려가도록 액션을 정의했습니다. 이 액션이 실행되면 텍스트가 삭제되면서 플레이스홀더가 재활성화됩니다.

---

### 3. UIApplication에 endEditing() 메서드 확장 추가

```swift
import UIKit

extension UIApplication {
    func endEditing() {
        sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
    }
}
```
이 코드는 UIApplication에 endEditing() 메서드를 추가하기 위한 확장입니다. 이 메서드는 앱 내에서 현재 활성화된 키보드를 내리기 위한 작업을 수행합니다. 이 메서드는 아래의 코드에서 사용되며, Image(systemName: "xmark.circle.fill") 이미지를 터치할 때 호출됩니다.

```swift
.onTapGesture {
    text = ""
    UIApplication.shared.endEditing()
}
```
이 확장을 추가하여 UITextField의 resignFirstResponder 액션을 통해 키보드가 내려가도록 구현했습니다. 이 기능의 도입으로 사용자들이 쉽게 키보드를 내릴 수 있어 원활한 사용자 경험을 제공합니다.

## 기타 사항 (Etc)
- [참고했던 코드](https://velog.io/@j_aion/SwiftUI-CryptoApp-Search-Bar-w7juo75z)


## 관련 사진(Optional)
![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-08-21 at 20 53 27](https://github.com/M1zz/RelaxOn/assets/108422901/b34e1c63-f82b-4299-950c-00159c4001a6)
